### PR TITLE
Clarify some undo endblock info

### DIFF
--- a/toonz/sources/tnztools/skeletontool.cpp
+++ b/toonz/sources/tnztools/skeletontool.cpp
@@ -328,7 +328,7 @@ void SkeletonTool::leftButtonDown(const TPointD &ppos, const TMouseEvent &e) {
   m_otherColumnBBoxAff = TAffine();
   m_labelPos           = TPointD(0, 0);
   m_label              = "";
-
+  // This undo block ends in leftButtonUp
   TUndoManager::manager()->beginBlock();
   if (!doesApply()) return;
 

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -3115,7 +3115,7 @@ static void createNewDrawing(TXsheet *xsh, int row, int col,
   const Type *Var = dynamic_cast<const Type *>(Data)
 
 void TCellSelection::dPasteCells() {
-  if (isEmpty())  // Se la selezione delle celle e' vuota ritorno.
+  if (isEmpty()) 
     return;
   int r0, c0, r1, c1;
   getSelectedCells(r0, c0, r1, c1);
@@ -3124,7 +3124,10 @@ void TCellSelection::dPasteCells() {
   QClipboard *clipboard     = QApplication::clipboard();
   const QMimeData *mimeData = clipboard->mimeData();
   if (DYNAMIC_CAST(TCellData, cellData, mimeData)) {
-    if (!cellData->canChange(xsh, c0)) return;
+      if (!cellData->canChange(xsh, c0)) {
+          TUndoManager::manager()->endBlock();
+          return;
+      }
     for (int c = 0; c < cellData->getColCount(); c++) {
       for (int r = 0; r < cellData->getRowCount(); r++) {
         TXshCell src = cellData->getCell(r, c);

--- a/toonz/sources/toonzqt/functionpaneltools.cpp
+++ b/toonz/sources/toonzqt/functionpaneltools.cpp
@@ -106,6 +106,7 @@ MovePointDragTool::MovePointDragTool(FunctionPanel *panel, TDoubleParam *curve)
     , m_speed1Index(-1)
     , m_groupEnabled(false)
     , m_selection(0) {
+    // This undo block is closed in the destructor
   TUndoManager::manager()->beginBlock();
 
   if (curve) {

--- a/toonz/sources/toonzqt/fxselection.cpp
+++ b/toonz/sources/toonzqt/fxselection.cpp
@@ -258,8 +258,11 @@ bool FxSelection::insertPasteSelection() {
     fxsData->getFxs(fxs, zeraryFxColumnSize, columns);
     if (fxs.empty() && columns.empty()) return true;
 
-    if (!auto_.m_destruct)
-      auto_.m_destruct = true, TUndoManager::manager()->beginBlock();
+    // auto ends the undo block in the destructor.
+    if (!auto_.m_destruct) {
+        auto_.m_destruct = true;
+        TUndoManager::manager()->beginBlock();
+    }
 
     TFxCommand::insertPasteFxs(selectedLinks[i], fxs.toStdList(),
                                zeraryFxColumnSize.toStdMap(),
@@ -300,6 +303,7 @@ bool FxSelection::addPasteSelection() {
     fxsData->getFxs(fxs, zeraryFxColumnSize, columns);
     if (fxs.empty() && columns.empty()) return true;
 
+    // auto ends the undo block in its destructor
     if (!auto_.m_destruct)
       auto_.m_destruct = true, TUndoManager::manager()->beginBlock();
 
@@ -343,6 +347,7 @@ bool FxSelection::replacePasteSelection() {
     fxsData->getFxs(fxs, zeraryFxColumnSize, columns);
     if (fxs.empty() && columns.empty()) return true;
 
+    // auto ends the undo block in its destructor
     if (!auto_.m_destruct)
       auto_.m_destruct = true, TUndoManager::manager()->beginBlock();
 
@@ -377,8 +382,9 @@ void FxSelection::ungroupSelection() {
 
   TUndoManager::manager()->beginBlock();
   QSet<int>::iterator it;
-  for (it = idSet.begin(); it != idSet.end(); it++)
-    TFxCommand::ungroupFxs(*it, m_xshHandle);
+  for (it = idSet.begin(); it != idSet.end(); it++) {
+      TFxCommand::ungroupFxs(*it, m_xshHandle);
+  }
   TUndoManager::manager()->endBlock();
   selectNone();
   m_xshHandle->notifyXsheetChanged();


### PR DESCRIPTION
In an effort to track down undo bugs, I went through the code and made sure that any place a undo beginblock was called, endblock would be called also.  I had fixed some of these when I did the paste images feature.  I found one more here, but it looks like it is in a function that isn't used anymore, but I fixed it anyway.