### PR TITLE
Fix missing shortcuts

### DIFF
--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -549,7 +549,7 @@ ToonzVectorBrushTool::ToonzVectorBrushTool(std::string name, int targetType)
   m_autoGroup.setId("AutoGroup");
 
   m_prop[0].bind(m_autoFill);
-  m_autoFill.setId("AutoFill");
+  m_autoFill.setId("Autofill");
 
   m_prop[0].bind(m_sendToBack);
   m_sendToBack.setId("DrawUnder");

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1766,6 +1766,9 @@ void MainWindow::defineActions() {
       MI_SavePaletteAs, tr("&Save Palette As..."), "",
       tr("Save the current style palette as a separate file with a new name."));
   createRightClickMenuAction(
+      MI_SaveStudioPalette, tr("&Save Studio Palette"), "",
+      tr("Save the current Studio Palette."));
+  createRightClickMenuAction(
       MI_OverwritePalette, tr("&Save Palette"), "",
       tr("Save the current style palette as a separate file."));
   createRightClickMenuAction(MI_SaveAsDefaultPalette,
@@ -2724,6 +2727,8 @@ void MainWindow::defineActions() {
                           tr("Brush Tool - Draw Order"), "");
   createToolOptionsAction("A_ToolOption_Smooth", tr("Smooth"), "");
   createToolOptionsAction("A_ToolOption_Snap", tr("Snap"), "");
+  createToolOptionsAction("A_ToolOption_AutoClose", tr("Auto Close"), "");
+  createToolOptionsAction("A_ToolOption_DrawUnder", tr("Draw Under"), "");
   createToolOptionsAction("A_ToolOption_AutoSelectDrawing",
                           tr("Auto Select Drawing"), "");
   createToolOptionsAction("A_ToolOption_Autofill", tr("Auto Fill"), "");

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -35,6 +35,7 @@
 #define MI_SaveLevelAs "MI_SaveLevelAs"
 #define MI_ExportLevel "MI_ExportLevel"
 #define MI_SavePaletteAs "MI_SavePaletteAs"
+#define MI_SaveStudioPalette "MI_SaveStudioPalette"
 #define MI_OverwritePalette "MI_OverwritePalette"
 #define MI_SaveAsDefaultPalette "MI_SaveAsDefaultPalette"
 #define MI_LoadColorModel "MI_LoadColorModel"

--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -663,7 +663,7 @@ void StudioPaletteCmd::updateAllLinkedStyles(TPaletteHandle *paletteHandle,
     }
   }
   if (!paletteHandle || !paletteHandle->getPalette()) return;
-  if (somethingChanged) paletteHandle->notifyColorStyleChanged();
+  if (somethingChanged) paletteHandle->notifyColorStyleChanged(false);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When I added the vector auto close and draw under options, I didn't create the ability to assign them to a shortcut.  This fixes that.

I also added a shortcut for saving the studio palette.
closes #274 
