### PR TITLE
Fix for crash when deleting control point while moving it.

### DIFF
--- a/toonz/sources/tnztools/controlpointselection.cpp
+++ b/toonz/sources/tnztools/controlpointselection.cpp
@@ -1076,6 +1076,10 @@ void ControlPointSelection::setUnlinear() {
 //-----------------------------------------------------------------------------
 
 void ControlPointSelection::deleteControlPoints() {
+  if (!m_controlPointEditorStroke) {
+    m_arePointsDeleted = true;
+    return;
+  }
   TTool *tool = TTool::getApplication()->getCurrentTool()->getTool();
   TVectorImageP vi(tool->getImage(false));
   int currentStrokeIndex = m_controlPointEditorStroke->getStrokeIndex();

--- a/toonz/sources/tnztools/controlpointselection.h
+++ b/toonz/sources/tnztools/controlpointselection.h
@@ -140,6 +140,7 @@ private:
   std::set<int> m_selectedPoints;
   int m_strokeIndex;
   ControlPointEditorStroke *m_controlPointEditorStroke;
+  bool m_arePointsDeleted = false;
 
 public:
   ControlPointSelection() : m_controlPointEditorStroke(0), m_strokeIndex(-1) {}
@@ -161,6 +162,10 @@ public:
   void addMenuItems(QMenu *menu);
 
   void enableCommands() override;
+
+  bool getPointsDeleted() { return m_arePointsDeleted; }
+  void setArePointsDeleted(bool value) { m_arePointsDeleted = value; }
+  std::set<int> getSelectedPoints() { return m_selectedPoints; }
 
 protected slots:
   void setLinear();


### PR DESCRIPTION
A crash can occur when deleting a control point while moving it.
This fixes this particular issue.  However, there are other instances where commands can get called while a tool is active.
That should be addressed at some point.

This also restores the selection of control points after moving them.  Previously, the selection was lost after moving control points.  This is handy if after moving points, you want to nudge them with the arrows.