### PR TITLE
Fix Adjust Current Level to Studio Palette links

### DIFF
--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -506,7 +506,10 @@ void adaptLevelToPalette(TXshLevelHandle *currentLevelHandle,
   QApplication::restoreOverrideCursor();
 
   currentLevelHandle->getSimpleLevel()->setPalette(plt);
+
+  std::wstring oldGlobalName = paletteHandle->getPalette()->getGlobalName();
   paletteHandle->setPalette(plt);
+  paletteHandle->getPalette()->setGlobalName(oldGlobalName);
   plt->setDirtyFlag(true);
   paletteHandle->notifyPaletteChanged();
   currentLevelHandle->notifyLevelChange();


### PR DESCRIPTION
This fixes #246 

This is apparently a pre-existing OT issue.  When using the `Adjust Current Level to This Palette` it would not allow you to toggle the link between the Level Palette and the Studio Palette.

Cause: Studio Palettes are internally named and certain actions are not enabled for it. When the Studio Palette adjusted the Level Palette, the Studio's Palette's name is copied to the Level Palette preventing it from enabling the commands to link back.

Fix: After adjusting the level palette, the level palette's internal name is reset to what it was before, usually blank.