### PR TITLE
Add missing options to combo viewer

### DIFF
--- a/toonz/sources/toonz/comboviewerpane.cpp
+++ b/toonz/sources/toonz/comboviewerpane.cpp
@@ -198,6 +198,22 @@ ComboViewerPanel::ComboViewerPanel(QWidget *parent, Qt::WFlags flags)
 
   m_flipConsole->setChecked(FlipConsole::eSound, true);
   m_playSound = m_flipConsole->isChecked(FlipConsole::eSound);
+  m_flipConsole->setFrameRate(app->getCurrentScene()
+                                  ->getScene()
+                                  ->getProperties()
+                                  ->getOutputProperties()
+                                  ->getFrameRate());
+
+  UINT mask = 0;
+  mask      = mask | eShowVcr;
+  mask      = mask | eShowFramerate;
+  mask      = mask | eShowViewerControls;
+  mask      = mask | eShowSound;
+  mask      = mask | eShowCustom;
+  mask      = mask & ~eShowSave;
+  mask      = mask & ~eShowLocator;
+  mask      = mask & ~eShowHisto;
+  m_flipConsole->setCustomizemask(mask);
 
   // initial state of the parts
   m_visiblePartsFlag = CVPARTS_ALL;
@@ -216,7 +232,8 @@ void ComboViewerPanel::updateShowHide() {
   // tool options bar
   m_toolOptions->setVisible(m_visiblePartsFlag & CVPARTS_TOOLOPTIONS);
   // flip console
-  m_flipConsole->showHideAllParts(m_visiblePartsFlag & CVPARTS_FLIPCONSOLE);
+  m_flipConsole->showHidePlaybar(m_visiblePartsFlag & CVPARTS_PLAYBAR);
+  m_flipConsole->showHideFrameSlider(m_visiblePartsFlag & CVPARTS_FRAMESLIDER);
   update();
 }
 
@@ -237,7 +254,8 @@ void ComboViewerPanel::addShowHideContextMenu(QMenu *menu) {
   // actions
   QAction *toolbarSHAct     = showHideMenu->addAction(tr("Toolbar"));
   QAction *toolOptionsSHAct = showHideMenu->addAction(tr("Tool Options Bar"));
-  QAction *flipConsoleSHAct = showHideMenu->addAction(tr("Console"));
+  QAction *playbarSHAct     = showHideMenu->addAction(tr("Playback Toolbar"));
+  QAction *frameSliderSHAct = showHideMenu->addAction(tr("Frame Slider"));
 
   toolbarSHAct->setCheckable(true);
   toolbarSHAct->setChecked(m_visiblePartsFlag & CVPARTS_TOOLBAR);
@@ -247,15 +265,20 @@ void ComboViewerPanel::addShowHideContextMenu(QMenu *menu) {
   toolOptionsSHAct->setChecked(m_visiblePartsFlag & CVPARTS_TOOLOPTIONS);
   toolOptionsSHAct->setData((UINT)CVPARTS_TOOLOPTIONS);
 
-  flipConsoleSHAct->setCheckable(true);
-  flipConsoleSHAct->setChecked(m_visiblePartsFlag & CVPARTS_FLIPCONSOLE);
-  flipConsoleSHAct->setData((UINT)CVPARTS_FLIPCONSOLE);
+  playbarSHAct->setCheckable(true);
+  playbarSHAct->setChecked(m_visiblePartsFlag & CVPARTS_PLAYBAR);
+  playbarSHAct->setData((UINT)CVPARTS_PLAYBAR);
+
+  frameSliderSHAct->setCheckable(true);
+  frameSliderSHAct->setChecked(m_visiblePartsFlag & CVPARTS_FRAMESLIDER);
+  frameSliderSHAct->setData((UINT)CVPARTS_FRAMESLIDER);
 
   QActionGroup *showHideActGroup = new QActionGroup(this);
   showHideActGroup->setExclusive(false);
   showHideActGroup->addAction(toolbarSHAct);
   showHideActGroup->addAction(toolOptionsSHAct);
-  showHideActGroup->addAction(flipConsoleSHAct);
+  showHideActGroup->addAction(playbarSHAct);
+  showHideActGroup->addAction(frameSliderSHAct);
 
   connect(showHideActGroup, SIGNAL(triggered(QAction *)), this,
           SLOT(onShowHideActionTriggered(QAction *)));
@@ -425,7 +448,7 @@ void ComboViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
 
   TPanelTitleBarButtonSet *viewModeButtonSet;
   m_referenceModeBs = viewModeButtonSet = new TPanelTitleBarButtonSet();
-  int x                                 = -232;
+  int x                                 = -272;
   int iconWidth                         = 20;
   TPanelTitleBarButton *button;
 
@@ -447,7 +470,7 @@ void ComboViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
 
   button = new TPanelTitleBarButton(
       titleBar, getIconThemePath("actions/20/pane_grid.svg"));
-  button->setToolTip(tr("Field Guide"));
+  button->setToolTip(tr("Grids and Overlays\nRight click to adjust."));
   x += 1 + iconWidth;
   titleBar->add(QPoint(x, 0), button);
   ret = ret && connect(button, SIGNAL(toggled(bool)),
@@ -459,11 +482,20 @@ void ComboViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
   button->setPressed(
       CommandManager::instance()->getAction(MI_FieldGuide)->isChecked());
 
+  TPanelTitleBarButtonForGrids *gridMoreButton =
+      new TPanelTitleBarButtonForGrids(
+          titleBar, getIconThemePath("actions/9/pane_more.svg"));
+  gridMoreButton->setToolTip(tr("Grids and Overlays Settings"));
+  x += 1 + iconWidth;
+  titleBar->add(QPoint(x, 0), gridMoreButton);
+  connect(gridMoreButton, &TPanelTitleBarButtonForGrids::updateViewer,
+          [=]() { m_sceneViewer->update(); });
+
   // view mode toggles
   button = new TPanelTitleBarButton(
       titleBar, getIconThemePath("actions/20/pane_table.svg"));
   button->setToolTip(tr("Camera Stand View"));
-  x += 10 + 1 + iconWidth;
+  x += 10 + iconWidth;
   titleBar->add(QPoint(x, 0), button);
   button->setButtonSet(viewModeButtonSet, SceneViewer::NORMAL_REFERENCE);
   button->setPressed(true);
@@ -475,15 +507,23 @@ void ComboViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
   titleBar->add(QPoint(x, 0), button);
   button->setButtonSet(viewModeButtonSet, SceneViewer::CAMERA3D_REFERENCE);
 
-  TPanelTitleBarButtonForCameraView* camButton =
-      new TPanelTitleBarButtonForCameraView(
-          titleBar, getIconThemePath("actions/20/pane_cam.svg"));
-  camButton->setToolTip(tr("Camera View"));
+  button = new TPanelTitleBarButton(
+      titleBar, getIconThemePath("actions/20/pane_cam.svg"));
+  button->setToolTip(tr("Camera View"));
   x += +1 + iconWidth;
-  titleBar->add(QPoint(x, 0), camButton);
-  camButton->setButtonSet(viewModeButtonSet, SceneViewer::CAMERA_REFERENCE);
-  connect(camButton, &TPanelTitleBarButtonForCameraView::updateViewer,
-      [=]() { m_sceneViewer->update(); });
+  titleBar->add(QPoint(x, 0), button);
+  button->setButtonSet(viewModeButtonSet, SceneViewer::CAMERA_REFERENCE);
+
+  TPanelTitleBarButtonForCameraView *camTransparencyButton =
+      new TPanelTitleBarButtonForCameraView(
+          titleBar, getIconThemePath("actions/9/pane_more.svg"));
+  camTransparencyButton->setToolTip(tr("Change camera view transparency."));
+  x += 1 + iconWidth;
+  titleBar->add(QPoint(x, 0), camTransparencyButton);
+  connect(camTransparencyButton,
+          &TPanelTitleBarButtonForCameraView::updateViewer,
+          [=]() { m_sceneViewer->update(); });
+
   ret = ret && connect(viewModeButtonSet, SIGNAL(selected(int)), m_sceneViewer,
                        SLOT(setReferenceMode(int)));
 
@@ -508,7 +548,7 @@ void ComboViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
 
   m_subcameraPreviewButton = new TPanelTitleBarButton(
       titleBar, getIconThemePath("actions/20/pane_subpreview.svg"));
-  x += +1 + 24;  // width of pane_preview_off.svg = 24px
+  x += +1 + 24;  // width of pane_preview.svg = 24px
 
   titleBar->add(QPoint(x, 0), m_subcameraPreviewButton);
   m_subcameraPreviewButton->setToolTip(tr("Sub-camera Preview"));

--- a/toonz/sources/toonz/comboviewerpane.h
+++ b/toonz/sources/toonz/comboviewerpane.h
@@ -35,9 +35,11 @@ enum CV_Parts {
   CVPARTS_None        = 0,
   CVPARTS_TOOLBAR     = 0x1,
   CVPARTS_TOOLOPTIONS = 0x2,
-  CVPARTS_FLIPCONSOLE = 0x4,
-  CVPARTS_End         = 0x8,
-  CVPARTS_ALL = CVPARTS_TOOLBAR | CVPARTS_TOOLOPTIONS | CVPARTS_FLIPCONSOLE
+  CVPARTS_PLAYBAR     = 0x4,
+  CVPARTS_FRAMESLIDER = 0x8,
+  CVPARTS_End         = 0x16,
+  CVPARTS_ALL = CVPARTS_TOOLBAR | CVPARTS_TOOLOPTIONS | CVPARTS_PLAYBAR |
+                CVPARTS_FRAMESLIDER
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -394,10 +394,10 @@ void ChangeObjectParent::refresh() {
   TXsheet *xsh                   = m_xsheetHandle->getXsheet();
   TStageObjectId currentObjectId = m_objectHandle->getObjectId();
   TStageObjectId parentId = xsh->getStageObject(currentObjectId)->getParent();
-  TStageObject* currentObject = xsh->getStageObject(currentObjectId);
-  std::list<TStageObject*> children = currentObject->getChildren();
-  TStageObjectTree *tree  = xsh->getStageObjectTree();
-  int objectCount         = tree->getStageObjectCount();
+  TStageObject *currentObject        = xsh->getStageObject(currentObjectId);
+  std::list<TStageObject *> children = currentObject->getChildren();
+  TStageObjectTree *tree             = xsh->getStageObjectTree();
+  int objectCount                    = tree->getStageObjectCount();
   QString text;
   QList<QString> pegbarList;
   QList<QString> columnList;
@@ -422,8 +422,9 @@ void ChangeObjectParent::refresh() {
         }
       }
     }
-    
-    bool found = (std::find(children.begin(), children.end(), xsh->getStageObject(id)) != children.end());
+
+    bool found = (std::find(children.begin(), children.end(),
+                            xsh->getStageObject(id)) != children.end());
 
     if (id == currentObjectId || found) continue;
     if (id.isTable()) {
@@ -465,7 +466,7 @@ void ChangeObjectParent::refresh() {
   // set font size in pixel
   font.setPixelSize(XSHEET_FONT_PX_SIZE);
 
-  m_width             = std::max(QFontMetrics(font).width(theLongestTxt) + 22, 71);
+  m_width = std::max(QFontMetrics(font).width(theLongestTxt) + 22, 71);
   std::string strText = text.toStdString();
   selectCurrent(text);
 }
@@ -479,7 +480,7 @@ void ChangeObjectParent::onTextChanged(const QString &text) {
     hide();
     return;
   }
-  bool isPegbar = false;
+  bool isPegbar                        = false;
   if (text.startsWith("Peg")) isPegbar = true;
   bool isTable                         = false;
   if (text == "Table") isTable         = true;
@@ -741,7 +742,7 @@ void ColumnArea::DrawHeader::levelColors(QColor &columnColor,
   }
   enum { Normal, Reference, Control } usage = Reference;
   if (column) {
-    if (column->isControl()) usage = Control;
+    if (column->isControl()) usage                             = Control;
     if (column->isRendered() || column->getMeshColumn()) usage = Normal;
   }
 
@@ -759,7 +760,7 @@ void ColumnArea::DrawHeader::paletteColors(QColor &columnColor,
                                            QColor &dragColor) const {
   enum { Normal, Reference, Control } usage = Reference;
   if (column) {  // Check if column is a mask
-    if (column->isControl()) usage = Control;
+    if (column->isControl()) usage  = Control;
     if (column->isRendered()) usage = Normal;
   }
 
@@ -1867,11 +1868,11 @@ m_value->setFont(font);*/
 
   bool ret = connect(m_slider, SIGNAL(sliderReleased()), this,
                      SLOT(onSliderReleased()));
-  ret      = ret && connect(m_slider, SIGNAL(sliderMoved(int)), this,
+  ret = ret && connect(m_slider, SIGNAL(sliderMoved(int)), this,
                        SLOT(onSliderChange(int)));
-  ret      = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
+  ret = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
                        SLOT(onSliderValueChanged(int)));
-  ret      = ret && connect(m_value, SIGNAL(textChanged(const QString &)), this,
+  ret = ret && connect(m_value, SIGNAL(textChanged(const QString &)), this,
                        SLOT(onValueChanged(const QString &)));
 
   ret = ret && connect(m_filterColorCombo, SIGNAL(activated(int)), this,
@@ -1984,11 +1985,11 @@ SoundColumnPopup::SoundColumnPopup(QWidget *parent)
 
   bool ret = connect(m_slider, SIGNAL(sliderReleased()), this,
                      SLOT(onSliderReleased()));
-  ret      = ret && connect(m_slider, SIGNAL(sliderMoved(int)), this,
+  ret = ret && connect(m_slider, SIGNAL(sliderMoved(int)), this,
                        SLOT(onSliderChange(int)));
-  ret      = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
+  ret = ret && connect(m_slider, SIGNAL(valueChanged(int)), this,
                        SLOT(onSliderValueChanged(int)));
-  ret      = ret && connect(m_value, SIGNAL(textChanged(const QString &)), this,
+  ret = ret && connect(m_value, SIGNAL(textChanged(const QString &)), this,
                        SLOT(onValueChanged(const QString &)));
   assert(ret);
 }
@@ -2297,17 +2298,21 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
             event->button() == Qt::RightButton)
           return;
         if (!xsh->getColumn(m_col)->getSoundTextColumn()) {
+          int x = 0;
+          x = Preferences::instance()->isShowXSheetToolbarEnabled() ? 30 : 0;
           TStageObjectId columnId = m_viewer->getObjectId(m_col);
           bool isColumn = xsh->getStageObject(columnId)->getParent().isColumn();
-          bool clickChangeParent = isColumn ? o->rect(PredefinedRect::PEGBAR_NAME)
-              .adjusted(0, 0, -20, 0)
-              .contains(mouseInCell) : o->rect(PredefinedRect::PEGBAR_NAME)
-              .contains(mouseInCell);
+          bool clickChangeParent =
+              isColumn
+                  ? o->rect(PredefinedRect::PEGBAR_NAME)
+                        .adjusted(0, 0, -20, 0)
+                        .contains(mouseInCell)
+                  : o->rect(PredefinedRect::PEGBAR_NAME).contains(mouseInCell);
           if (clickChangeParent) {
             m_changeObjectParent->refresh();
             m_changeObjectParent->show(QPoint(
                 o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
-                m_viewer->positionToXY(CellPosition(0, m_col)) +
+                m_viewer->positionToXY(CellPosition(0, m_col)) + QPoint(0, x) +
                 QPoint(o->rect(PredefinedRect::CAMERA_CELL).width(), 4) -
                 QPoint(m_viewer->getColumnScrollValue(), 0)));
             return;
@@ -2319,7 +2324,7 @@ void ColumnArea::mousePressEvent(QMouseEvent *event) {
             m_changeObjectHandle->show(QPoint(
                 o->rect(PredefinedRect::PARENT_HANDLE_NAME).bottomLeft() +
                 m_viewer->positionToXY(CellPosition(0, m_col + 1)) +
-                QPoint(2, 0) - QPoint(m_viewer->getColumnScrollValue(), 0)));
+                QPoint(2, x) - QPoint(m_viewer->getColumnScrollValue(), 0)));
             return;
           }
         }
@@ -2383,8 +2388,8 @@ void ColumnArea::mouseMoveEvent(QMouseEvent *event) {
     return;
   }
 
-  int col = m_viewer->xyToPosition(pos).layer();
-  if (col < -1) col = 0;
+  int col            = m_viewer->xyToPosition(pos).layer();
+  if (col < -1) col  = 0;
   TXsheet *xsh       = m_viewer->getXsheet();
   TXshColumn *column = xsh->getColumn(col);
   QPoint mouseInCell = pos - m_viewer->positionToXY(CellPosition(0, col));


### PR DESCRIPTION
There were a handful of things that hadn't made their way to the combo viewer:
The new overlay menu
The ability to hide the playback toolbar separately from the frame scrubber in the console
The simplified default button set for the console.

This brings them over.

I also found out what was going on with #272 
If the xsheet toolbar was visible, it was pushing down the header and covering the dropdown.  This checks to see if the xsheet toolbar is on and positions the dropdown accordingly.