### PR TITLE
All ctrl + shift to toggle snapping on the geometry tool

### DIFF
--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -128,26 +128,29 @@ void StatusBar::makeMap() {
                     "Animate Tool: Modifies the position, rotation and size of "
                     "the current column"});
   m_infoMap.insert({"T_Brush", "Brush Tool: Draws in the work area freehand"});
-  m_infoMap.insert(
-      {"T_BrushVector", "Brush Tool: Draws in the work area freehand" + spacer +
-                            "Shift - Straight Lines" + spacer +
+  m_infoMap.insert({"T_BrushVector",
+                    "Brush Tool: Draws in the work area freehand" + spacer +
+                        "Shift - Straight Lines" + spacer +
                         "Control - Straight Lines Snapped to Angles" + spacer +
                         "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
                         "Alt - Draw to Vanishing Point" + spacer +
-                            "Hold Ctrl + Shift - Toggle Snapping"});
+                        "Hold Ctrl + Shift - Toggle Snapping"});
   m_infoMap.insert({"T_BrushSmartRaster",
                     "Brush Tool: Draws in the work area freehand" + spacer +
                         "Shift - Straight Lines" + spacer +
                         "Control - Straight Lines Snapped to Angles" + spacer +
                         "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
                         "Alt - Draw to Vanishing Point"});
-  m_infoMap.insert(
-      {"T_BrushRaster", "Brush Tool: Draws in the work area freehand" + spacer +
-                            "Shift - Straight Lines" + spacer +
-                            "Control - Straight Lines Snapped to Angles" + spacer +
-                            "Ctrl + Alt - Add / Remove Vanishing Point" +
-                            spacer + "Alt - Draw to Vanishing Point"});
+  m_infoMap.insert({"T_BrushRaster",
+                    "Brush Tool: Draws in the work area freehand" + spacer +
+                        "Shift - Straight Lines" + spacer +
+                        "Control - Straight Lines Snapped to Angles" + spacer +
+                        "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
+                        "Alt - Draw to Vanishing Point"});
   m_infoMap.insert({"T_Geometric", "Geometry Tool: Draws geometric shapes"});
+  m_infoMap.insert({ "T_GeometricVector", "Geometry Tool: Draws geometric shapes" +
+                                       spacer +
+                                       "Hold Ctrl + Shift - Toggle Snapping" });
   m_infoMap.insert({"T_Type", "Type Tool: Adds text"});
   m_infoMap.insert(
       {"T_PaintBrush",


### PR DESCRIPTION
This makes it possible to temporarily toggle snapping by holding ctrl + shift, same as the vector brush.