### PR TITLE
Fix resizing windows on start

### DIFF
--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -533,8 +533,7 @@ public:
 
   unsigned int find(const Region *subRegion) const;
 
-  bool checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
-                                  bool &fromDocking);
+  bool checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets);
   // This causes issues on maximize if the timeline is too tall.
   // bool checkWidgetsToBeFixedHeight(std::vector<QWidget *> &widgets,
   //                                 bool &fromDocking);


### PR DESCRIPTION
fixes #192 

I had made a change earlier that would not lock in a windows fixed width if it was being docked, to make docking windows from a floating state place the windows a little more naturally, but on mac that was causing issues with window sizes on restarting.

I reverted the change.