### PR TITLE
Build script corrections

### DIFF
--- a/ci-scripts/linux/tahoma-build.sh
+++ b/ci-scripts/linux/tahoma-build.sh
@@ -5,7 +5,10 @@ popd
 
 cd toonz
 
-mkdir build
+if [ ! -d build ]
+then
+   mkdir build
+fi
 cd build
 
 source /opt/qt59/bin/qt59-env.sh
@@ -14,3 +17,4 @@ cmake ../sources \
     -DWITH_SYSTEM_SUPERLU:BOOL=OFF
 
 make -j7
+

--- a/ci-scripts/linux/tahoma-buildffmpeg.sh
+++ b/ci-scripts/linux/tahoma-buildffmpeg.sh
@@ -1,6 +1,6 @@
 cd thirdparty
 
-echo ">>> Cloning openH254"
+echo ">>> Cloning openH264"
 git clone https://github.com/cisco/openh264.git openh264
 
 cd openh264
@@ -20,7 +20,7 @@ git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 cd ffmpeg
 echo "*" >| .gitignore
 
-echo ">>> Configuring to build ffmpeg"
+echo ">>> Configuring to build ffmpeg (shared)"
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 ./configure  --prefix=/usr/local \
@@ -55,11 +55,59 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
       --disable-libjack \
       --disable-indev=jack
 
-echo ">>> Building ffmpeg"
+echo ">>> Building ffmpeg (shared)"
 make
 
-echo ">>> Installing ffmpeg"
+echo ">>> Installing ffmpeg (shared)"
 sudo make install
 
 sudo ldconfig
+
+echo ">>> Configuring to build ffmpeg (static)"
+
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+./configure  --prefix=/usr/local \
+      --pkg-config-flags="--static" \
+      --extra-cflags="-I/usr/local/include -static" \
+      --extra-ldflags="-L/usr/local/lib -static" \
+      --extra-ldexeflags="-static" \
+      --enable-static \
+      --enable-cross-compile \
+      --enable-pic \
+      --disable-shared \
+      --enable-libopenh264 \
+      --enable-pthreads \
+      --enable-version3 \
+      --enable-avresample \
+      --enable-libmp3lame \
+      --enable-libopus \
+      --enable-libsnappy \
+      --enable-libtheora \
+      --enable-libvorbis \
+      --enable-libvpx \
+      --enable-libwebp \
+      --enable-lzma \
+      --enable-libfreetype \
+      --enable-libopencore-amrnb \
+      --enable-libopencore-amrwb \
+      --enable-libspeex \
+      --disable-ffplay \
+      --disable-htmlpages \
+      --disable-manpages \
+      --disable-podpages \
+      --disable-txtpages \
+      --disable-libjack \
+      --disable-indev=jack
+
+echo ">>> Building ffmpeg (static)"
+make
+
+echo ">>> Installing to tahoma2d/thirdparty/ffmpeg/bin"
+if [ ! -d bin ]
+then
+   mkdir bin
+fi
+
+cp ffmpeg ffprobe bin/
 

--- a/ci-scripts/linux/tahoma-buildopencv.sh
+++ b/ci-scripts/linux/tahoma-buildopencv.sh
@@ -6,7 +6,10 @@ git clone https://github.com/opencv/opencv.git
 cd opencv
 echo "*" >| .gitignore
 
-mkdir build
+if [ ! -d build ]
+then
+   mkdir build
+fi
 cd build
 
 echo ">>> Cmaking openv"
@@ -49,3 +52,4 @@ make
 
 echo ">>> Installing opencv"
 sudo make install
+

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -9,7 +9,10 @@ sudo make install
 sudo ldconfig
 
 echo ">>> Creating appDir"
-rm -rf appdir
+if [ -d appdir ]
+then
+   rm -rf appdir
+fi
 mkdir -p appdir/usr
 
 echo ">>> Copy and configure Tahoma2D installation in appDir"
@@ -20,7 +23,10 @@ mv appdir/usr/lib/tahoma2d/* appdir/usr/lib
 rmdir appdir/usr/lib/tahoma2d
 
 echo ">>> Creating Tahoma2D directory"
-rm -rf Tahoma2D
+if [ -d Tahoma2D ]
+then
+   rm -rf Tahoma2D
+fi
 mkdir Tahoma2D
 
 echo ">>> Copying stuff to Tahoma2D/tahomastuff"
@@ -32,6 +38,10 @@ rmdir appdir/usr/share/tahoma2d
 if [ -d ../../thirdparty/ffmpeg/bin ]
 then
    echo ">>> Copying FFmpeg to Tahoma2D/ffmpeg"
+   if [ -d Tahoma2D/ffmpeg ]
+   then
+      rm -rf Tahoma2D/ffmpeg
+   fi
    cp -R ../../thirdparty/ffmpeg/bin Tahoma2D/ffmpeg
 fi
 
@@ -59,3 +69,4 @@ mv Tahoma2D*.AppImage Tahoma2D/Tahoma2D.AppImage
 echo ">>> Creating Tahoma2D Linux package"
 
 tar zcf Tahoma2D-linux.tar.gz Tahoma2D
+

--- a/ci-scripts/osx/tahoma-build.sh
+++ b/ci-scripts/osx/tahoma-build.sh
@@ -5,7 +5,10 @@ popd
 
 cd toonz
 
-mkdir build
+if [ ! -d build ]
+then
+   mkdir build
+fi
 cd build
 
 QTVERSION=`ls /usr/local/Cellar/qt`
@@ -16,6 +19,7 @@ then
    export CANON_FLAG=-DWITH_CANON=ON
 fi
 
+export MACOSX_DEPLOYMENT_TARGET=10.13
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/jpeg-turbo/lib/pkgconfig"
 cmake ../sources  $CANON_FLAG \
       -DQT_PATH=/usr/local/opt/qt/lib/ \

--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -6,8 +6,8 @@ git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
 cd ffmpeg
 echo "*" >| .gitignore
 
-echo ">>> Configuring to build ffmpeg"
-export PKG_CONFIG_PATH=/usr/local/lib/pkconfig
+echo ">>> Configuring to build ffmpeg (shared)"
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 ./configure  --prefix=/usr/local \
       --enable-shared \
@@ -42,8 +42,42 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkconfig
       --disable-libjack \
       --disable-indev=jack
 
-echo ">>> Building ffmpeg"
+echo ">>> Building ffmpeg (shared)"
 make -j7 # runs 7 jobs in parallel
 
-echo ">>> Installing ffmpeg"
-make install
+echo ">>> Installing ffmpeg (shared)"
+sudo make install
+
+echo ">>> Configuring to build ffmpeg (static)"
+make clean
+
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+export SDKROOT=`xcrun --show-sdk-path`
+./configure  --prefix=/usr/local \
+      --pkg-config-flags="--static" \
+      --enable-static \
+      --disable-shared \
+      --enable-pic \
+      --disable-shared \
+      --enable-pthreads \
+      --enable-version3 \
+      --enable-videotoolbox \
+      --enable-avresample \
+      --enable-libaom \
+      --enable-libxml2 \
+      --enable-libvpx \
+      --disable-ffplay \
+      --disable-sdl2 \
+      --disable-libjack \
+      --disable-indev=jack
+
+echo ">>> Building ffmpeg (static)"
+make -j7 # runs 7 jobs in parallel
+
+echo ">>> Installing to tahoma2d/thirdparty/ffmpeg/bin"
+if [ ! -d bin ]
+then
+   mkdir bin
+fi
+
+cp ffmpeg ffprobe bin/

--- a/ci-scripts/osx/tahoma-buildopencv.sh
+++ b/ci-scripts/osx/tahoma-buildopencv.sh
@@ -6,7 +6,10 @@ git clone https://github.com/opencv/opencv.git
 cd opencv
 echo "*" >| .gitignore
 
-mkdir build
+if [ ! -d build ]
+then
+   mkdir build
+fi
 cd build
 
 echo ">>> Cmaking openv"
@@ -49,4 +52,4 @@ echo ">>> Building opencv"
 make -j7 # runs 7 jobs in parallel
 
 echo ">>> Installing opencv"
-make install
+sudo make install

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -9,18 +9,32 @@ then
 fi
 
 echo ">>> Copying stuff to $TOONZDIR/Tahoma2D.app/tahomastuff"
+if [ -d $TOONZDIR/Tahoma2D.app/tahomastuff ]
+then
+   # In case of prior builds, replace stuff folder
+   rm -rf $TOONZDIR/Tahoma2D.app/tahomastuff
+fi
 cp -R stuff $TOONZDIR/Tahoma2D.app/tahomastuff
 
 if [ -d thirdparty/ffmpeg/bin ]
 then
    echo ">>> Copying FFmpeg to $TOONZDIR/Tahoma2D.app/ffmpeg"
+   if [ -d $TOONZDIR/Tahoma2D.app/ffmpeg ]
+   then
+      # In case of prior builds, replace ffmpeg folder
+      rm -rf $TOONZDIR/Tahoma2D.app/ffmpeg
+   fi
    cp -R thirdparty/ffmpeg/bin $TOONZDIR/Tahoma2D.app/ffmpeg
 fi
 
 if [ -d thirdparty/canon/Framework ]
 then
    echo ">>> Copying canon framework to $TOONZDIR/Tahoma2D.app/Contents/Frameworks/EDSDK.Framework"
-   cp -R thirdparty/canon/Framework $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+   if [ ! -d $TOONZDIR/Tahoma2D.app/Contents/Frameworks ]
+   then
+      mkdir $TOONZDIR/Tahoma2D.app/Contents/Frameworks
+   fi
+   cp -R thirdparty/canon/Framework/ $TOONZDIR/Tahoma2D.app/Contents/Frameworks
 fi
 
 echo ">>> Configuring Tahoma2D.app for deployment"

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -3,7 +3,6 @@ brew update
 # from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
 # so we start to use the latest version of Qt. (#1910)
 brew install qt clang-format glew lz4 lzo libusb libmypaint jpeg-turbo nasm yasm aom dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
-brew tap tcr/tcr
 # delete older qt versions and make sure to have only the latest
 brew cleanup qt
 # temp workaround to brew installed glew cmake info overriding glew lib detection


### PR DESCRIPTION
This PR does the following with the macOS/linux build scripts

1. Fixes macOS build script issues and suggestions brought up by @artisteacher  (thanks!)
2. Fix re-running the buikdpkg scripts to only create certain things when needed or remove certain things before redeploying.
3. After building the shared ffmpeg library needed for opencv compiling, it builds a static ffmpeg to be used for deployments.