### PR TITLE
Make setting markers easier

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2094,6 +2094,12 @@ void MainWindow::defineActions() {
                                    tr("Remove Multiple Keys"), "");
   menuAct->setIcon(createQIcon("remove_multiple_keys"));
 
+  menuAct = createMenuXsheetAction(MI_SetInMarker, tr("Set In Marker"), "");
+  menuAct = createMenuXsheetAction(MI_SetOutMarker, tr("Set Out Marker"), "");
+  menuAct = createMenuXsheetAction(MI_ClearMarkers, tr("Remove Markers"), "");
+  menuAct = createMenuXsheetAction(MI_SetAutoMarkers, tr("Set Auto Markers"), "");
+  menuAct = createMenuXsheetAction(MI_PreviewThis, tr("Set Markers to Current Frame"), "");
+
   menuAct = createMenuLevelAction(MI_NewNoteLevel, tr("New Note Level"), "");
   menuAct->setIcon(createQIcon("new_note_level"));
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2094,8 +2094,8 @@ void MainWindow::defineActions() {
                                    tr("Remove Multiple Keys"), "");
   menuAct->setIcon(createQIcon("remove_multiple_keys"));
 
-  menuAct = createMenuXsheetAction(MI_SetInMarker, tr("Set In Marker"), "");
-  menuAct = createMenuXsheetAction(MI_SetOutMarker, tr("Set Out Marker"), "");
+  menuAct = createMenuXsheetAction(MI_SetStartMarker, tr("Set Start Marker"), "");
+  menuAct = createMenuXsheetAction(MI_SetStopMarker, tr("Set Stop Marker"), "");
   menuAct = createMenuXsheetAction(MI_ClearMarkers, tr("Remove Markers"), "");
   menuAct = createMenuXsheetAction(MI_SetAutoMarkers, tr("Set Auto Markers"), "");
   menuAct = createMenuXsheetAction(MI_PreviewThis, tr("Set Markers to Current Frame"), "");

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -137,6 +137,12 @@
 #define MI_InsertFx "MI_InsertFx"
 #define MI_NewOutputFx "MI_NewOutputFx"
 
+#define MI_SetInMarker "MI_SetInMarker"
+#define MI_SetOutMarker "MI_SetOutMarker"
+#define MI_ClearMarkers "MI_ClearMarkers"
+#define MI_SetAutoMarkers "MI_SetAutoMarkers"
+#define MI_PreviewThis "MI_PreviewThis"
+
 #define MI_PasteNew "MI_PasteNew"
 #define MI_Autorenumber "MI_Autorenumber"
 #define MI_CreateBlankDrawing "MI_CreateBlankDrawing"

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -137,8 +137,8 @@
 #define MI_InsertFx "MI_InsertFx"
 #define MI_NewOutputFx "MI_NewOutputFx"
 
-#define MI_SetInMarker "MI_SetInMarker"
-#define MI_SetOutMarker "MI_SetOutMarker"
+#define MI_SetStartMarker "MI_SetStartMarker"
+#define MI_SetStopMarker "MI_SetStopMarker"
 #define MI_ClearMarkers "MI_ClearMarkers"
 #define MI_SetAutoMarkers "MI_SetAutoMarkers"
 #define MI_PreviewThis "MI_PreviewThis"

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -49,7 +49,8 @@
 #include "toonzqt/menubarcommand.h"
 #include "toonzqt/stageobjectsdata.h"
 #include "historytypes.h"
-
+#include "xsheetdragtool.h"
+#include "xsheetviewer.h"
 // Tnz6 includes
 #include "cellselection.h"
 #include "columnselection.h"
@@ -2142,3 +2143,129 @@ public:
   }
 
 } ToggleXsheetCameraColumnCommand;
+
+
+//============================================================
+
+class SetInMarker final : public MenuItemHandler {
+public:
+    SetInMarker()
+        : MenuItemHandler(MI_SetInMarker) {}
+    void execute() override { 
+        int frame = TApp::instance()->getCurrentFrame()->getFrame();
+        assert(frame >= 0);
+
+        int r0, r1, step;
+        XsheetGUI::getPlayRange(r0, r1, step);
+        if (r0 > r1) {
+            r0 = 0;
+            r1 = TApp::instance()->getCurrentScene()->getScene()->getFrameCount() - 1;
+            if (r1 < 1) r1 = 1;
+        }
+        r0 = frame;
+        if (r1 < r0) r1 = r0;
+        XsheetGUI::setPlayRange(r0, r1, step);
+        TApp::instance()->getCurrentXsheetViewer()->update();
+    }
+} SetInMarker;
+
+//============================================================
+
+class SetOutMarker final : public MenuItemHandler {
+public:
+    SetOutMarker()
+        : MenuItemHandler(MI_SetOutMarker) {}
+    void execute() override {
+        int frame = TApp::instance()->getCurrentFrame()->getFrame();
+        assert(frame >= 0);
+
+        int r0, r1, step;
+        XsheetGUI::getPlayRange(r0, r1, step);
+        if (r0 > r1) {
+            r0 = 0;
+            r1 = TApp::instance()->getCurrentScene()->getScene()->getFrameCount() - 1;
+            if (r1 < 1) r1 = 1;
+        }
+        r1 = frame;
+        if (r1 < r0) r0 = r1;
+        r1 -= (step == 0) ? (r1 - r0) : (r1 - r0) % step;
+        XsheetGUI::setPlayRange(r0, r1, step);
+        TApp::instance()->getCurrentXsheetViewer()->update();
+    }
+} SetOutMarker;
+
+//============================================================
+
+class ClearMarkers final : public MenuItemHandler {
+public:
+    ClearMarkers()
+        : MenuItemHandler(MI_ClearMarkers) {}
+    void execute() override {
+        int step, r0, r1;
+        XsheetGUI::getPlayRange(r0, r1, step);
+        XsheetGUI::setPlayRange(0, -1, step);
+        TApp::instance()->getCurrentXsheetViewer()->update();
+    }
+} ClearMarkers;
+
+//============================================================
+
+class SetAutoMarkers final : public MenuItemHandler {
+public:
+    SetAutoMarkers()
+        : MenuItemHandler(MI_SetAutoMarkers) {}
+
+    enum Direction { up = 0, down };
+
+    int getNonEmptyCell(int row, int column, Direction direction) {
+        int currentPos = row;
+        bool exit = false;
+
+        while (!exit) {
+            TXshCell cell = TApp::instance()->getCurrentXsheetViewer()->getXsheet()->getCell(currentPos, column);
+            if (cell.isEmpty()) {
+                (direction == up) ? currentPos++ : currentPos--;
+                exit = true;
+            }
+            else
+                (direction == up) ? currentPos-- : currentPos++;
+        }
+
+        return currentPos;
+    }
+
+    void execute() override {
+        int col = TApp::instance()->getCurrentColumn()->getColumnIndex();
+        int row = TApp::instance()->getCurrentFrame()->getFrame();
+        TXshCell cell =
+            TApp::instance()->getCurrentXsheetViewer()->getXsheet()->getCell(row, col);
+        if (cell.isEmpty()) return;
+        int step, r0, r1;
+
+        int top = getNonEmptyCell(row, col, Direction::up);
+        int bottom = getNonEmptyCell(row, col, Direction::down);
+
+        XsheetGUI::getPlayRange(r0, r1, step);
+        XsheetGUI::setPlayRange(top, bottom, step);
+        TApp::instance()->getCurrentXsheetViewer()->update();
+
+    }
+} SetAutoMarkers;
+
+//============================================================
+
+class PreviewThis final : public MenuItemHandler {
+public:
+    PreviewThis()
+        : MenuItemHandler(MI_PreviewThis) {}
+
+    void execute() override {
+        int row = TApp::instance()->getCurrentFrame()->getFrame();
+        assert(row >= 0);
+        int r0, r1, step;
+        XsheetGUI::getPlayRange(r0, r1, step);
+        XsheetGUI::setPlayRange(row, row, step);
+        TApp::instance()->getCurrentXsheetViewer()->update();
+
+    }
+} PreviewThis;

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -2147,10 +2147,10 @@ public:
 
 //============================================================
 
-class SetInMarker final : public MenuItemHandler {
+class SetStartMarker final : public MenuItemHandler {
 public:
-    SetInMarker()
-        : MenuItemHandler(MI_SetInMarker) {}
+    SetStartMarker()
+        : MenuItemHandler(MI_SetStartMarker) {}
     void execute() override { 
         int frame = TApp::instance()->getCurrentFrame()->getFrame();
         assert(frame >= 0);
@@ -2167,14 +2167,14 @@ public:
         XsheetGUI::setPlayRange(r0, r1, step);
         TApp::instance()->getCurrentXsheetViewer()->update();
     }
-} SetInMarker;
+} SetStartMarker;
 
 //============================================================
 
-class SetOutMarker final : public MenuItemHandler {
+class SetStopMarker final : public MenuItemHandler {
 public:
-    SetOutMarker()
-        : MenuItemHandler(MI_SetOutMarker) {}
+    SetStopMarker()
+        : MenuItemHandler(MI_SetStopMarker) {}
     void execute() override {
         int frame = TApp::instance()->getCurrentFrame()->getFrame();
         assert(frame >= 0);
@@ -2192,7 +2192,7 @@ public:
         XsheetGUI::setPlayRange(r0, r1, step);
         TApp::instance()->getCurrentXsheetViewer()->update();
     }
-} SetOutMarker;
+} SetStopMarker;
 
 //============================================================
 

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1206,10 +1206,10 @@ void RowArea::mouseReleaseEvent(QMouseEvent *event) {
       CommandManager::instance()->execute(MI_ClearMarkers);
   }
   else if (m_mousePressRow == -1 && (event->modifiers() & Qt::ControlModifier)) {
-      CommandManager::instance()->execute(MI_SetInMarker);
+      CommandManager::instance()->execute(MI_SetStartMarker);
   }
   else if (m_mousePressRow == -1 && (event->modifiers() & Qt::AltModifier)) {
-      CommandManager::instance()->execute(MI_SetOutMarker);
+      CommandManager::instance()->execute(MI_SetStopMarker);
   }
 }
 
@@ -1220,9 +1220,9 @@ void RowArea::contextMenuEvent(QContextMenuEvent *event) {
       TApp::instance()->getCurrentOnionSkin()->getOnionSkinMask();
 
   QMenu *menu             = new QMenu(this);
-  menu->addAction(CommandManager::instance()->getAction(MI_SetInMarker));
+  menu->addAction(CommandManager::instance()->getAction(MI_SetStartMarker));
   
-  menu->addAction(CommandManager::instance()->getAction(MI_SetOutMarker));
+  menu->addAction(CommandManager::instance()->getAction(MI_SetStopMarker));
   
 
   QAction* setAutoMarkers = CommandManager::instance()->getAction(MI_SetAutoMarkers);
@@ -1269,23 +1269,6 @@ bool RowArea::canSetAutoMarkers() {
   TXshCell cell =
       m_viewer->getXsheet()->getCell(m_row, m_viewer->getCurrentColumn());
   return cell.isEmpty() ? false : true;
-}
-
-//-----------------------------------------------------------------------------
-int RowArea::getNonEmptyCell(int row, int column, Direction direction) {
-  int currentPos = row;
-  bool exit      = false;
-
-  while (!exit) {
-    TXshCell cell = m_viewer->getXsheet()->getCell(currentPos, column);
-    if (cell.isEmpty()) {
-      (direction == up) ? currentPos++ : currentPos--;
-      exit = true;
-    } else
-      (direction == up) ? currentPos-- : currentPos++;
-  }
-
-  return currentPos;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -61,9 +61,6 @@ class RowArea final : public QWidget {
 
   // Return when the item-menu setAutoMarkers can be enabled.
   bool canSetAutoMarkers();
-  // Return the number of the last non-empty cell finded. You can set the
-  // direction of the search.
-  int getNonEmptyCell(int row, int column, Direction);
 
 public:
 #if QT_VERSION >= 0x050500

--- a/toonz/sources/toonz/xshrowviewer.h
+++ b/toonz/sources/toonz/xshrowviewer.h
@@ -83,19 +83,6 @@ protected:
   void mouseDoubleClickEvent(QMouseEvent *event) override;
   bool event(QEvent *event) override;
 
-  void setMarker(int index);
-
-protected slots:
-
-  void onSetStartMarker();
-  void onSetStopMarker();
-  void onRemoveMarkers();
-
-  // Set start and end marker automatically respect the current row and column.
-  void onSetAutoMarkers();
-
-  // set both the from and to markers at the specified row
-  void onPreviewThis();
 };
 
 }  // namespace XsheetGUI;


### PR DESCRIPTION
closes #321 

This makes it possible to assign as shortcut to set and remove markers and auto markers.

It also allows you to:
Ctrl + Click in the frame number area to set the in marker
Alt + Click in the frame number area to set the out marker
and Ctrl + Alt + Click in the frame number area to clear the markers.