### PR TITLE
Option to show the color of the parent column in the header

### DIFF
--- a/stuff/config/qss/Dark/Dark.qss
+++ b/stuff/config/qss/Dark/Dark.qss
@@ -2237,6 +2237,8 @@ XsheetViewer {
   qproperty-EmptyCellColor: #282828;
   qproperty-NotEmptyColumnColor: #303030;
   qproperty-SelectedEmptyCellColor: rgba(90, 100, 106, 0.5);
+  qproperty-PegColor: #9f6e3c;
+  qproperty-TableColor: #62628c;
   qproperty-LevelColumnColor: #4C6E4C;
   qproperty-LevelColumnBorderColor: #375037;
   qproperty-SelectedLevelColumnColor: #59846c;

--- a/stuff/config/qss/Darker/Darker.qss
+++ b/stuff/config/qss/Darker/Darker.qss
@@ -2237,6 +2237,8 @@ XsheetViewer {
   qproperty-EmptyCellColor: #202020;
   qproperty-NotEmptyColumnColor: #282828;
   qproperty-SelectedEmptyCellColor: rgba(83, 93, 100, 0.5);
+  qproperty-PegColor: #9f6e3c;
+  qproperty-TableColor: #62628c;
   qproperty-LevelColumnColor: #4C6E4C;
   qproperty-LevelColumnBorderColor: #375037;
   qproperty-SelectedLevelColumnColor: #59846c;

--- a/stuff/config/qss/Light/Light.qss
+++ b/stuff/config/qss/Light/Light.qss
@@ -2237,6 +2237,8 @@ XsheetViewer {
   qproperty-EmptyCellColor: #c2c2c2;
   qproperty-NotEmptyColumnColor: #cecece;
   qproperty-SelectedEmptyCellColor: rgba(146, 153, 158, 0.5);
+  qproperty-PegColor: #dfb081;
+  qproperty-TableColor: #cbcbe4;
   qproperty-LevelColumnColor: #9ed49e;
   qproperty-LevelColumnBorderColor: #72b472;
   qproperty-SelectedLevelColumnColor: #92bfa0;

--- a/stuff/config/qss/Medium/Medium.qss
+++ b/stuff/config/qss/Medium/Medium.qss
@@ -2237,6 +2237,8 @@ XsheetViewer {
   qproperty-EmptyCellColor: #393939;
   qproperty-NotEmptyColumnColor: #404040;
   qproperty-SelectedEmptyCellColor: rgba(103, 113, 119, 0.5);
+  qproperty-PegColor: #9f6e3c;
+  qproperty-TableColor: #62628c;
   qproperty-LevelColumnColor: #4C6E4C;
   qproperty-LevelColumnBorderColor: #375037;
   qproperty-SelectedLevelColumnColor: #59846c;

--- a/stuff/config/qss/Medium/less/layouts/xsheet.less
+++ b/stuff/config/qss/Medium/less/layouts/xsheet.less
@@ -98,6 +98,9 @@ XsheetViewer {
   qproperty-SelectedEmptyCellColor: @xsheet-SelectedEmptyCell-color;
 
   // Level Type Colors
+  qproperty-PegColor: saturate(lighten(@schematic-PegColor, @nodeLightness), @nodeSaturation);
+  qproperty-TableColor: saturate(lighten(@schematic-TableColor, @nodeLightness), @nodeSaturation);
+
   qproperty-LevelColumnColor: @xsheet-LevelColumn-color;
   qproperty-LevelColumnBorderColor: desaturate(darken(@xsheet-LevelColumn-color, @columnBorderDarkness), @columnBorderDesaturation);
   qproperty-SelectedLevelColumnColor: mix(shade(@xsheet-LevelColumn-color, @cellHighlightLightness), @cellHighlightTintColor, @cellHighlightTintAmount);

--- a/stuff/config/qss/Neutral/Neutral.qss
+++ b/stuff/config/qss/Neutral/Neutral.qss
@@ -2237,6 +2237,8 @@ XsheetViewer {
   qproperty-EmptyCellColor: #6c6c6c;
   qproperty-NotEmptyColumnColor: #767676;
   qproperty-SelectedEmptyCellColor: rgba(155, 159, 162, 0.5);
+  qproperty-PegColor: #be8a56;
+  qproperty-TableColor: #a4a4bf;
   qproperty-LevelColumnColor: #78a578;
   qproperty-LevelColumnBorderColor: #537d53;
   qproperty-SelectedLevelColumnColor: #90bd98;

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -52,6 +52,7 @@
 
 // TnzCore includes
 #include "tconvert.h"
+#include "tenv.h"
 
 #include <QApplication>
 #include <QMainWindow>
@@ -66,6 +67,8 @@
 #include <QDesktopWidget>
 
 #include <QBitmap>
+
+TEnv::IntVar ShowParentColorsInXsheet("ShowParentColorsInXsheet", 1);
 //=============================================================================
 
 namespace {
@@ -1183,9 +1186,25 @@ void ColumnArea::DrawHeader::drawPegbarName() const {
   if (column->getSoundColumn() || column->getSoundTextColumn() ||
       column->getPaletteColumn())
     return;
-
+  if (ShowParentColorsInXsheet == 1) {
+    QColor parentColor = Qt::black;
+    if (parentId.isCamera()) {
+      parentColor = m_viewer->getActiveCameraColor();
+    } else if (parentId.isPegbar()) {
+      parentColor = m_viewer->getPegColor();
+    } else if (parentId.isTable()) {
+      parentColor = m_viewer->getTableColor();
+    } else if (parentId.isColumn()) {
+      int columnIndex = parentId.getIndex();
+      QColor unused;
+      m_viewer->getColumnColor(parentColor, unused, columnIndex, xsh);
+    }
+    if (parentColor != Qt::black) {
+      p.fillRect(pegbarnamerect, parentColor);
+      p.drawRect(pegbarnamerect);
+    }
+  }
   p.setPen(m_viewer->getTextColor());
-
   p.drawText(pegbarnamerect.adjusted(3, 0, 0, 0),
              Qt::AlignLeft | Qt::AlignVCenter | Qt::TextSingleLine, name);
 }
@@ -2720,7 +2739,9 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       menu.addSeparator();
       menu.addAction(cmdManager->getAction(MI_InsertFx));
       menu.addAction(cmdManager->getAction(MI_NewNoteLevel));
-      menu.addAction(cmdManager->getAction(MI_RemoveEmptyColumns));
+      if (!o->isVerticalTimeline()) {
+        menu.addAction(cmdManager->getAction(MI_RemoveEmptyColumns));
+      }
       menu.addSeparator();
       if (m_viewer->getXsheet()->isColumnEmpty(col) ||
           (cell.m_level && cell.m_level->getChildLevel()))
@@ -2758,7 +2779,7 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
 
     QAction *flipOrientation = new QAction(tr("Toggle Orientation"), this);
 
-    flipOrientation->setToolTip(tr("Toggle between timeline and xsheet view"));
+    flipOrientation->setToolTip(tr("Toggle Between Timeline and Xsheet View"));
     bool ret = true;
     ret      = ret && connect(flipOrientation, &QAction::triggered,
                          [=]() { m_viewer->flipOrientation(); });
@@ -2817,6 +2838,21 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       //  assert(ret);
       //  menu.addAction(setMask);
       //}
+    }
+    if (o->isVerticalTimeline()) {
+      menu.addSeparator();
+      QAction *showParentColors =
+          new QAction(tr("Show Column Parent Colors"), this);
+      showParentColors->setCheckable(true);
+      showParentColors->setChecked(ShowParentColorsInXsheet == 1 ? true
+                                                                 : false);
+      showParentColors->setToolTip(
+          tr("Show the column parent's color in the Xsheet"));
+
+      connect(showParentColors, &QAction::toggled, [=]() {
+        ShowParentColorsInXsheet = showParentColors->isChecked() ? 1 : 0;
+      });
+      menu.addAction(showParentColors);
     }
   }
 

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -348,6 +348,16 @@ class XsheetViewer final : public QFrame, public SaveLoadQSettings {
                  setMeshColumnBorderColor)
   Q_PROPERTY(QColor SelectedMeshColumnColor READ getSelectedMeshColumnColor
                  WRITE setSelectedMeshColumnColor)
+
+  // Table color
+  QColor m_tableColor;
+  Q_PROPERTY(QColor TableColor READ getTableColor WRITE setTableColor)
+
+  // Peg node
+  QColor m_pegColor;
+  Q_PROPERTY(QColor PegColor READ getPegColor WRITE setPegColor)
+
+  // Peg color
   // SoundText column
   QColor m_soundTextColumnColor;
   QColor m_soundTextColumnBorderColor;
@@ -937,6 +947,15 @@ public:
   QColor getSelectedMeshColumnColor() const {
     return m_selectedMeshColumnColor;
   }
+
+  // Table node
+  void setTableColor(const QColor &color) { m_tableColor = color; }
+  QColor getTableColor() const { return m_tableColor; }
+
+  // Peg node
+  void setPegColor(const QColor &color) { m_pegColor = color; }
+  QColor getPegColor() const { return m_pegColor; }
+
   // SoundText column
   void setSoundTextColumnColor(const QColor &color) {
     m_soundTextColumnColor = color;


### PR DESCRIPTION
closes #91 
Adds the option to show the columns parent color in the parent section of the xsheet header.  This is toggleable with a checkbox in the context menu.

![more parents](https://user-images.githubusercontent.com/4576381/95545911-69e44000-09bc-11eb-8584-0ef54092119f.PNG)
