### PR TITLE
Fix colors on various checks.

### DIFF
--- a/toonz/sources/common/trop/quickput.cpp
+++ b/toonz/sources/common/trop/quickput.cpp
@@ -3233,12 +3233,17 @@ void doQuickPutCmapped(const TRaster32P &dn, const TRasterCM32P &up,
   std::vector<TPixel32> paints(palette->getStyleCount());
   std::vector<TPixel32> inks(palette->getStyleCount());
 
-  if (s.m_transparencyCheck)
+  if (s.m_transparencyCheck && !s.m_isOnionSkin) {
     for (int i = 0; i < palette->getStyleCount(); i++) {
-      paints[i] = s.m_transpCheckPaint;
-      inks[i]   = s.m_blackBgCheck ? s.m_transpCheckBg : s.m_transpCheckInk;
+      if (i == s.m_gapCheckIndex) {
+        paints[i] = inks[i] = applyColorScaleCMapped(
+            palette->getStyle(i)->getAverageColor(), s.m_globalColorScale);
+      } else {
+        paints[i] = s.m_transpCheckPaint;
+        inks[i]   = s.m_blackBgCheck ? s.m_transpCheckBg : s.m_transpCheckInk;
+      }
     }
-  else if (s.m_globalColorScale == TPixel::Black)
+  } else if (s.m_globalColorScale == TPixel::Black)
     for (int i  = 0; i < palette->getStyleCount(); i++)
       paints[i] = inks[i] =
           ::premultiply(palette->getStyle(i)->getAverageColor());

--- a/toonz/sources/include/trop.h
+++ b/toonz/sources/include/trop.h
@@ -178,13 +178,16 @@ public:
 
   int m_inkIndex, m_paintIndex;
 
-  bool m_inksOnly, m_transparencyCheck, m_blackBgCheck;
+  bool m_inksOnly, m_transparencyCheck, m_blackBgCheck, m_isOnionSkin;
+  int m_gapCheckIndex = -1;
 
   CmappedQuickputSettings()
       : m_globalColorScale(TPixel32::Black)
       , m_inksOnly(false)
       , m_transparencyCheck(false)
       , m_blackBgCheck(false)
+      , m_isOnionSkin(false)
+      , m_gapCheckIndex(-1)
       , m_inkIndex(-1)
       , m_paintIndex(-1) {}
 };

--- a/toonz/sources/tnztools/rastertapetool.cpp
+++ b/toonz/sources/tnztools/rastertapetool.cpp
@@ -205,7 +205,7 @@ public:
   }
 
   //------------------------------------------------------------
-  /*--  AutoCloseが実行されたらtrue,実行されなければfalseを返す --*/
+  /*--  AutoClose Returns true if executed, false otherwise --*/
   bool applyAutoclose(const TToonzImageP &ti, const TRectD &selRect = TRectD(),
                       TStroke *stroke = 0) {
     if (!ti) return false;

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1808,6 +1808,8 @@ void ToonzRasterBrushTool::leftButtonUp(const TPointD &pos,
   if (m_isStraight && m_isMyPaintStyleSelected && m_oldPressure > 0.0)
     pressure = m_oldPressure;
   finishRasterBrush(centeredPos, pressure);
+  int tc = ToonzCheck::instance()->getChecks();
+  if (tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) invalidate();
 }
 
 //---------------------------------------------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -261,13 +261,12 @@ void Picker::onImage(const Stage::Player &player) {
       double maxDist2  = maxDist * maxDist;
       double checkDist = maxDist2 * 4;
 
-      TStroke *stroke = vi->getStroke(strokeIndex);
+      TStroke *stroke        = vi->getStroke(strokeIndex);
       TThickPoint thickPoint = stroke->getThickPoint(w);
-      double thickness = thickPoint.thick;
-      double len = thickness * pixelSize * sqrt(m_viewAff.det());
-      checkDist = std::max(checkDist, (len * len));
-      if (dist2 < checkDist)
-        picked = true;
+      double thickness       = thickPoint.thick;
+      double len             = thickness * pixelSize * sqrt(m_viewAff.det());
+      checkDist              = std::max(checkDist, (len * len));
+      if (dist2 < checkDist) picked = true;
     }
   } else if (TRasterImageP ri = img) {
     TRaster32P ras = ri->getRaster();
@@ -574,11 +573,12 @@ void RasterPainter::flushRasterImages() {
       m_nodes[i].m_palette->setFrame(m_nodes[i].m_frame);
 
       TPaletteP plt;
+      int styleIndex = -1;
       if ((tc & ToonzCheck::eGap || tc & ToonzCheck::eAutoclose) &&
           m_nodes[i].m_isCurrentColumn) {
-        srcCm          = srcCm->clone();
-        plt            = m_nodes[i].m_palette->clone();
-        int styleIndex = plt->addStyle(TPixel::Magenta);
+        srcCm      = srcCm->clone();
+        plt        = m_nodes[i].m_palette->clone();
+        styleIndex = plt->addStyle(TPixel::Magenta);
         if (tc & ToonzCheck::eAutoclose)
           TAutocloser(srcCm, AutocloseDistance, AutocloseAngle, styleIndex,
                       AutocloseOpacity)
@@ -613,6 +613,9 @@ void RasterPainter::flushRasterImages() {
         Preferences::instance()->getTranspCheckData(
             settings.m_transpCheckBg, settings.m_transpCheckInk,
             settings.m_transpCheckPaint);
+
+        settings.m_isOnionSkin = m_nodes[i].m_onionMode != Node::eOnionSkinNone;
+        settings.m_gapCheckIndex = styleIndex;
 
         TRop::quickPut(viewedRaster, srcCm, plt, aff, settings);
       }
@@ -661,7 +664,7 @@ void RasterPainter::flushRasterImages() {
 #endif
 
 #ifdef GL_EXT_texture3D
-  if( GL_EXT_texture3D ) {
+  if (GL_EXT_texture3D) {
     glDisable(GL_TEXTURE_3D_EXT);
   }
 #endif
@@ -768,7 +771,7 @@ static void drawAutocloses(TVectorImage *vi, TVectorRenderData &rd) {
   buildAutocloseImage(vaux, vi, startPoints, endPoints);
   // temporarily disable fill check, to preserve the gap indicator color
   bool tCheckEnabledOriginal = rd.m_tcheckEnabled;
-  rd.m_tcheckEnabled = false;
+  rd.m_tcheckEnabled         = false;
   // draw
   tglDraw(rd, vaux);
   // restore original value
@@ -1075,11 +1078,11 @@ void RasterPainter::onToonzImage(TToonzImage *ti, const Stage::Player &player) {
   int alpha                 = 255;
   Node::OnionMode onionMode = Node::eOnionSkinNone;
   if (player.m_onionSkinDistance != c_noOnionSkin) {
-    // GetOnionSkinFade va bene per il vettoriale mentre il raster funziona al
-    // contrario
-    // 1 opaco -> 0 completamente trasparente
-    // inverto quindi il risultato della funzione stando attento al caso 0
-    // (in cui era scolpito il valore 0.9)
+    // GetOnionSkinFade is good for the vector while the raster works at the
+    //    Opposite 1 opaque -> 0 completely transparent
+    //    I therefore reverse the result of the function by being attentive to
+    //    case 0
+    //    (where the value 0.9 was carved)
     double onionSkiFade = player.m_onionSkinDistance == 0
                               ? 0.9
                               : (1.0 - OnionSkinMask::getOnionSkinFade(


### PR DESCRIPTION
This makes onion skin colors still show for Toonz Raster levels with Transparency Check or Fill Check on.

It also makes the Gap Check color on Toonz Raster levels still show of the above options are on.