### PR TITLE
Fix running through Linux shortcut

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -220,7 +220,17 @@ public:
   std::string getSystemVarPrefix() { return m_systemVarPrefix; }
 
   void setWorkingDirectory() {
-    QString workingDirectoryTmp  = QDir::currentPath();
+    QString workingDirectoryTmp = QDir::currentPath();
+
+#ifdef LINUX
+    QString appPath =
+        workingDirectoryTmp + "/" + QCoreApplication::applicationName();
+    QDir appDir(appPath);
+    appPath = appDir.canonicalPath();
+    if (!appPath.isEmpty())
+      workingDirectoryTmp = TFilePath(appPath).getParentDir().getQString();
+#endif
+
     QByteArray ba                = workingDirectoryTmp.toLatin1();
     const char *workingDirectory = ba.data();
     m_workingDirectory           = workingDirectory;

--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -6,6 +6,7 @@
 
 #include <QDir>
 #include <QSettings>
+#include <QCoreApplication>
 
 #ifdef LEVO_MACOSX
 
@@ -621,6 +622,12 @@ TFilePath TEnv::getConfigDir() {
   return fp != TFilePath() ? fp + "profiles" : fp;
 }
 */
+TFilePath TEnv::getWorkingDirectory() {
+  TFilePath workingDir(EnvGlobals::instance()->getWorkingDirectory());
+  if (workingDir == TFilePath()) workingDir = TFilePath(QDir::currentPath());
+  return workingDir;
+}
+
 void TEnv::setStuffDir(const TFilePath &stuffDir) {
   EnvGlobals::instance()->setStuffDir(stuffDir);
 }

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -37,23 +37,29 @@ bool Ffmpeg::checkFfmpeg() {
     Preferences::instance()->setValue(ffmpegPath, QDir::currentPath());
     return true;
   }
-    
+
 #ifdef MACOSX
-    path = QDir::currentPath() + "/" + QString::fromStdString(TEnv::getApplicationFileName()) + ".app/ffmpeg/ffmpeg";
-    if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-        Preferences::instance()->setValue(ffmpegPath, QDir::currentPath() + "/" + QString::fromStdString(TEnv::getApplicationFileName()) + ".app/ffmpeg/");
-        return true;
-    }
+  path = QDir::currentPath() + "/" +
+         QString::fromStdString(TEnv::getApplicationFileName()) +
+         ".app/ffmpeg/ffmpeg";
+  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+    Preferences::instance()->setValue(
+        ffmpegPath, QDir::currentPath() + "/" +
+                        QString::fromStdString(TEnv::getApplicationFileName()) +
+                        ".app/ffmpeg/");
+    return true;
+  }
 #endif
 
 #ifdef LINUX
-	path = QDir::currentPath() + "/ffmpeg/ffmpeg";
-	if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-		Preferences::instance()->setValue(ffmpegPath, QDir::currentPath() + "/ffmpeg/");
-		return true;
-	}
+  QString currentPath = TEnv::getWorkingDirectory().getQString();
+  path                = currentPath + "/ffmpeg/ffmpeg";
+  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+    Preferences::instance()->setValue(ffmpegPath, currentPath + "/ffmpeg/");
+    return true;
+  }
 #endif
-	// give up
+  // give up
   return false;
 }
 
@@ -74,24 +80,30 @@ bool Ffmpeg::checkFfprobe() {
     Preferences::instance()->setValue(ffmpegPath, QDir::currentPath());
     return true;
   }
-    
+
 #ifdef MACOSX
-    path = QDir::currentPath() + "/" + QString::fromStdString(TEnv::getApplicationFileName()) + ".app/ffmpeg/ffprobe";
-    if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-        Preferences::instance()->setValue(ffmpegPath, QDir::currentPath() + "/" + QString::fromStdString(TEnv::getApplicationFileName()) + ".app/ffmpeg/");
-        return true;
-    }
+  path = QDir::currentPath() + "/" +
+         QString::fromStdString(TEnv::getApplicationFileName()) +
+         ".app/ffmpeg/ffprobe";
+  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+    Preferences::instance()->setValue(
+        ffmpegPath, QDir::currentPath() + "/" +
+                        QString::fromStdString(TEnv::getApplicationFileName()) +
+                        ".app/ffmpeg/");
+    return true;
+  }
 #endif
 
 #ifdef LINUX
-	path = QDir::currentPath() + "/ffmpeg/ffprobe";
-	if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
-		Preferences::instance()->setValue(ffmpegPath, QDir::currentPath() + "/ffmpeg/");
-		return true;
-	}
+  QString currentPath = TEnv::getWorkingDirectory().getQString();
+  path                = currentPath + "/ffmpeg/ffprobe";
+  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+    Preferences::instance()->setValue(ffmpegPath, currentPath + "/ffmpeg/");
+    return true;
+  }
 #endif
 
-	// give up
+  // give up
   return false;
 }
 

--- a/toonz/sources/include/tenv.h
+++ b/toonz/sources/include/tenv.h
@@ -136,6 +136,7 @@ DVAPI TFilePathSet getSystemVarPathSetValue(std::string varName);
 DVAPI TFilePath getStuffDir();
 DVAPI TFilePath getConfigDir();
 // DVAPI TFilePath getProfilesDir();
+DVAPI TFilePath getWorkingDirectory();
 
 // per l'utilizzo di ToonzLib senza che sia definita una TOONZROOT
 // bisogna chiamare TEnv::setStuffDir(stuffdir) prima di ogni altra operazione

--- a/toonz/sources/sound/mp3/tsio_mp3.cpp
+++ b/toonz/sources/sound/mp3/tsio_mp3.cpp
@@ -5,6 +5,7 @@
 #include "tsystem.h"
 #include "tfilepath_io.h"
 #include "tsound_t.h"
+#include "tenv.h"
 #include "toonz/preferences.h"
 #include "toonz/toonzfolders.h"
 #include <QDir>
@@ -53,6 +54,28 @@ bool FfmpegAudio::checkFfmpeg() {
     Preferences::instance()->setValue(ffmpegPath, QDir::currentPath());
     return true;
   }
+
+#ifdef MACOSX
+  path = QDir::currentPath() + "/" +
+         QString::fromStdString(TEnv::getApplicationFileName()) +
+         ".app/ffmpeg/ffmpeg";
+  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+    Preferences::instance()->setValue(
+        ffmpegPath, QDir::currentPath() + "/" +
+                        QString::fromStdString(TEnv::getApplicationFileName()) +
+                        ".app/ffmpeg/");
+    return true;
+  }
+#endif
+
+#ifdef LINUX
+  QString currentPath = TEnv::getWorkingDirectory().getQString();
+  path                = currentPath + "/ffmpeg/ffmpeg";
+  if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+    Preferences::instance()->setValue(ffmpegPath, currentPath + "/ffmpeg/");
+    return true;
+  }
+#endif
 
   // give up
   return false;


### PR DESCRIPTION
This PR fixes #340 

For Linux systems, when launching from a shortcut (symbolic link), the working directory is where the application was started from so Tahoma2D cannot find the tahomastuff directory.

Added logic for Linux systems only, to attempt to convert a symbolic link to the true path of the application and set the working directory to that. 