### PR TITLE
WIP - Use the schematic hierarchy for ordering drawings in the viewer.

### DIFF
--- a/toonz/sources/common/tgl/tstencilcontrol.cpp
+++ b/toonz/sources/common/tgl/tstencilcontrol.cpp
@@ -285,10 +285,9 @@ void TStencilControl::Imp::popMask() {
 //---------------------------------------------------------
 //---------------------------------------------------------
 
-// questo forse e' un po' brutto:
-// La maschera e' chiusa.
-// Se e' abilitata,    open = push+open
-// Se e' disabilitata, open =      open
+// this is perhaps a bit ugly : the mask is closed.
+// If it's enabled,    open = push+open
+// If it's disabled, open =      open
 
 void TStencilControl::beginMask(DrawMode drawMode) {
   glPushAttrib(GL_ALL_ATTRIB_BITS);

--- a/toonz/sources/common/tgl/tstencilcontrol.cpp
+++ b/toonz/sources/common/tgl/tstencilcontrol.cpp
@@ -43,7 +43,7 @@ public:
   int m_stencilBitCount;
   int m_pushCount;
   int m_currentWriting;  // current stencil bit plane.
-  // 0 is the first bit plane ; -1 menas no stencil mask is writing
+  // 0 is the first bit plane ; -1 means no stencil mask is writing
 
   int m_virtualState;
 // the state of the (eventually virtual) top mask.
@@ -53,7 +53,7 @@ public:
 #ifdef _DEBUG
   std::stack<bool> fullState;
 // state of each mask in the stack (except top mask).
-// 'true' means opend; 'false' means close and enabled
+// 'true' means opened; 'false' means closed and enabled
 // Used only for assert
 #endif
 

--- a/toonz/sources/include/toonz/stage.h
+++ b/toonz/sources/include/toonz/stage.h
@@ -63,7 +63,7 @@ DVAPI void visit(Visitor &visitor, ToonzScene *scene, TXsheet *xsh, int row);
 
 //-----------------------------------------------------------------------------
 
-DVAPI void visitSimpleLevel(Visitor &visitor, TXshSimpleLevel *level,
+DVAPI void visit(Visitor &visitor, TXshSimpleLevel *level,
                             const TFrameId &fid, const OnionSkinMask &osm,
                             bool isPlaying, int isGuidedDrawingEnabled = 0,
                             int guidedBackStroke  = -1,
@@ -71,7 +71,7 @@ DVAPI void visitSimpleLevel(Visitor &visitor, TXshSimpleLevel *level,
 
 //-----------------------------------------------------------------------------
 
-DVAPI void visitSingleLevel(Visitor &visitor, TXshLevel *level,
+DVAPI void visit(Visitor &visitor, TXshLevel *level,
                             const TFrameId &fid, const OnionSkinMask &osm,
                             bool isPlaying, double isGuidedDrawingEnabled = 0.0,
                             int guidedBackStroke  = -1,

--- a/toonz/sources/include/toonz/stage.h
+++ b/toonz/sources/include/toonz/stage.h
@@ -63,14 +63,14 @@ DVAPI void visit(Visitor &visitor, ToonzScene *scene, TXsheet *xsh, int row);
 
 //-----------------------------------------------------------------------------
 
-DVAPI void visit(Visitor &visitor, TXshSimpleLevel *level, const TFrameId &fid,
+DVAPI void visitSimpleLevel(Visitor &visitor, TXshSimpleLevel *level, const TFrameId &fid,
                  const OnionSkinMask &osm, bool isPlaying,
                  int isGuidedDrawingEnabled = 0, int guidedBackStroke = -1,
                  int guidedFrontStroke = -1);
 
 //-----------------------------------------------------------------------------
 
-DVAPI void visit(Visitor &visitor, TXshLevel *level, const TFrameId &fid,
+DVAPI void visitSingleLevel(Visitor &visitor, TXshLevel *level, const TFrameId &fid,
                  const OnionSkinMask &osm, bool isPlaying,
                  double isGuidedDrawingEnabled = 0.0, int guidedBackStroke = -1,
                  int guidedFrontStroke = -1);

--- a/toonz/sources/include/toonz/stage.h
+++ b/toonz/sources/include/toonz/stage.h
@@ -63,17 +63,19 @@ DVAPI void visit(Visitor &visitor, ToonzScene *scene, TXsheet *xsh, int row);
 
 //-----------------------------------------------------------------------------
 
-DVAPI void visitSimpleLevel(Visitor &visitor, TXshSimpleLevel *level, const TFrameId &fid,
-                 const OnionSkinMask &osm, bool isPlaying,
-                 int isGuidedDrawingEnabled = 0, int guidedBackStroke = -1,
-                 int guidedFrontStroke = -1);
+DVAPI void visitSimpleLevel(Visitor &visitor, TXshSimpleLevel *level,
+                            const TFrameId &fid, const OnionSkinMask &osm,
+                            bool isPlaying, int isGuidedDrawingEnabled = 0,
+                            int guidedBackStroke  = -1,
+                            int guidedFrontStroke = -1);
 
 //-----------------------------------------------------------------------------
 
-DVAPI void visitSingleLevel(Visitor &visitor, TXshLevel *level, const TFrameId &fid,
-                 const OnionSkinMask &osm, bool isPlaying,
-                 double isGuidedDrawingEnabled = 0.0, int guidedBackStroke = -1,
-                 int guidedFrontStroke = -1);
+DVAPI void visitSingleLevel(Visitor &visitor, TXshLevel *level,
+                            const TFrameId &fid, const OnionSkinMask &osm,
+                            bool isPlaying, double isGuidedDrawingEnabled = 0.0,
+                            int guidedBackStroke  = -1,
+                            int guidedFrontStroke = -1);
 
 //-----------------------------------------------------------------------------
 }  // namespace Stage

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -134,6 +134,7 @@ struct DVAPI VisitArgs {
   bool m_onlyVisible;
   bool m_checkPreviewVisibility;
   bool m_rasterizePli;
+  bool m_useFxVisibility;
   int m_isGuidedDrawingEnabled;
   int m_guidedFrontStroke;
   int m_guidedBackStroke;
@@ -157,6 +158,7 @@ public:
       , m_isGuidedDrawingEnabled(0)
       , m_guidedFrontStroke(-1)
       , m_guidedBackStroke(-1)
+      , m_useFxVisibility(false)
       , m_rasterizePli(false) {}
 };
 

--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -62,6 +62,7 @@ extern TEnv::IntVar HorizonOffset;
 extern TEnv::IntVar ShowVanishingPointRays;
 extern TEnv::IntVar VanishingPointRayAngles;
 extern TEnv::IntVar VanishingPointRayOpacity;
+extern TEnv::IntVar CameraStandUseFxOrdering;
 
 //=============================================================================
 // TPanel
@@ -430,6 +431,36 @@ TPanelTitleBarButtonForCameraView::TPanelTitleBarButtonForCameraView(
 
 void TPanelTitleBarButtonForCameraView::mousePressEvent(QMouseEvent *e) {
   m_menu->exec(e->globalPos() + QPoint(-20, 10));
+}
+
+//-----------------------------------------------------------------------------
+
+TPanelTitleBarButtonForCamStandView::TPanelTitleBarButtonForCamStandView(
+    QWidget* parent, const QString& standardPixmapName)
+    : TPanelTitleBarButton(parent, standardPixmapName) {
+    m_menu = new QMenu(this);
+    QWidgetAction* menuAction = new QWidgetAction(this);
+    QWidget* menuWidget = new QWidget(this);
+    QGridLayout* menuLayout = new QGridLayout(this);
+
+    QCheckBox *schematicView = new QCheckBox(this);
+    schematicView->setChecked(CameraStandUseFxOrdering == 1 ? true : false);
+
+    connect(schematicView, &QCheckBox::toggled, [=](bool value) {
+        CameraStandUseFxOrdering = value ? 1 : 0;
+        emit updateViewer();
+        });
+    menuLayout->addWidget(new QLabel(tr("Use Fx Schematic Visiblity: ")), 0, 0, Qt::AlignRight);
+    menuLayout->addWidget(schematicView, 0, 1, Qt::AlignLeft);
+    menuWidget->setLayout(menuLayout);
+    menuAction->setDefaultWidget(menuWidget);
+    m_menu->addAction(menuAction);
+}
+
+//-----------------------------------------------------------------------------
+
+void TPanelTitleBarButtonForCamStandView::mousePressEvent(QMouseEvent* e) {
+    m_menu->exec(e->globalPos() + QPoint(-20, 10));
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/pane.h
+++ b/toonz/sources/toonz/pane.h
@@ -115,6 +115,25 @@ signals:
 
 //-----------------------------------------------------------------------------
 
+class TPanelTitleBarButtonForCamStandView final : public TPanelTitleBarButton {
+    Q_OBJECT
+
+        QMenu* m_menu;
+
+public:
+    TPanelTitleBarButtonForCamStandView(QWidget* parent,
+        const QString& standardPixmapName);
+
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override;
+
+signals:
+    void updateViewer();
+};
+
+//-----------------------------------------------------------------------------
+
 class TPanelTitleBarButtonForGrids final : public TPanelTitleBarButton {
     Q_OBJECT
 

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2085,7 +2085,7 @@ void SceneViewer::drawScene() {
     TFrameHandle *frameHandle = TApp::instance()->getCurrentFrame();
 
     if (app->getCurrentFrame()->isEditingLevel()) {
-      Stage::visit(painter, app->getCurrentLevel()->getLevel(),
+      Stage::visitSingleLevel(painter, app->getCurrentLevel()->getLevel(),
                    app->getCurrentFrame()->getFid(),
                    app->getCurrentOnionSkin()->getOnionSkinMask(),
                    frameHandle->isPlaying(), useGuidedDrawing, guidedBackStroke,
@@ -3118,7 +3118,7 @@ int SceneViewer::posToRow(const TPointD &p, double distance,
   picker.setDistance(distance);
 
   if (app->getCurrentFrame()->isEditingLevel()) {
-    Stage::visit(picker, app->getCurrentLevel()->getLevel(),
+    Stage::visitSingleLevel(picker, app->getCurrentLevel()->getLevel(),
                  app->getCurrentFrame()->getFid(), osm,
                  app->getCurrentFrame()->isPlaying(), false);
   } else {

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1016,51 +1016,58 @@ void SceneViewer::showEvent(QShowEvent *) {
   TApp *app = TApp::instance();
 
   TSceneHandle *sceneHandle = app->getCurrentScene();
-  bool ret = connect(sceneHandle, SIGNAL(sceneSwitched()), this, SLOT(resetSceneViewer()));
-  ret = ret && connect(sceneHandle, SIGNAL(sceneChanged()), this, SLOT(onSceneChanged()));
+  bool ret = connect(sceneHandle, SIGNAL(sceneSwitched()), this,
+                     SLOT(resetSceneViewer()));
+  ret = ret && connect(sceneHandle, SIGNAL(sceneChanged()), this,
+                       SLOT(onSceneChanged()));
 
   TFrameHandle *frameHandle = app->getCurrentFrame();
-  ret = ret && connect(frameHandle, SIGNAL(frameSwitched()), this, SLOT(onFrameSwitched()));
+  ret = ret && connect(frameHandle, SIGNAL(frameSwitched()), this,
+                       SLOT(onFrameSwitched()));
 
   TPaletteHandle *paletteHandle =
       app->getPaletteController()->getCurrentLevelPalette();
-  ret = ret && connect(paletteHandle, SIGNAL(colorStyleChanged(bool)), this, SLOT(update()));
+  ret = ret && connect(paletteHandle, SIGNAL(colorStyleChanged(bool)), this,
+                       SLOT(update()));
 
   ret = ret && connect(app->getCurrentObject(), SIGNAL(objectSwitched()), this,
-          SLOT(onObjectSwitched()));
-  ret = ret && connect(app->getCurrentObject(), SIGNAL(objectChanged(bool)), this,
-          SLOT(update()));
+                       SLOT(onObjectSwitched()));
+  ret = ret && connect(app->getCurrentObject(), SIGNAL(objectChanged(bool)),
+                       this, SLOT(update()));
 
-  ret = ret && connect(app->getCurrentOnionSkin(), SIGNAL(onionSkinMaskChanged()), this,
-          SLOT(onOnionSkinMaskChanged()));
+  ret =
+      ret && connect(app->getCurrentOnionSkin(), SIGNAL(onionSkinMaskChanged()),
+                     this, SLOT(onOnionSkinMaskChanged()));
 
   ret = ret && connect(app->getCurrentLevel(), SIGNAL(xshLevelChanged()), this,
-          SLOT(update()));
-  ret = ret && connect(app->getCurrentLevel(), SIGNAL(xshCanvasSizeChanged()), this,
-          SLOT(update()));
+                       SLOT(update()));
+  ret = ret && connect(app->getCurrentLevel(), SIGNAL(xshCanvasSizeChanged()),
+                       this, SLOT(update()));
   // when level is switched, update m_dpiScale in order to show white background
   // for Ink&Paint work properly
-  ret = ret && connect(app->getCurrentLevel(), SIGNAL(xshLevelSwitched(TXshLevel *)), this,
-          SLOT(onLevelSwitched()));
+  ret = ret &&
+        connect(app->getCurrentLevel(), SIGNAL(xshLevelSwitched(TXshLevel *)),
+                this, SLOT(onLevelSwitched()));
 
   ret = ret && connect(app->getCurrentXsheet(), SIGNAL(xsheetChanged()), this,
-          SLOT(onXsheetChanged()));
+                       SLOT(onXsheetChanged()));
   ret = ret && connect(app->getCurrentXsheet(), SIGNAL(xsheetSwitched()), this,
-          SLOT(update()));
+                       SLOT(update()));
 
   // update tooltip when tool options are changed
   ret = ret && connect(app->getCurrentTool(), SIGNAL(toolChanged()), this,
-          SLOT(onToolChanged()));
-  ret = ret && connect(app->getCurrentTool(), SIGNAL(toolCursorTypeChanged()), this,
-          SLOT(onToolChanged()));
+                       SLOT(onToolChanged()));
+  ret = ret && connect(app->getCurrentTool(), SIGNAL(toolCursorTypeChanged()),
+                       this, SLOT(onToolChanged()));
 
-  ret = ret && connect(app, SIGNAL(tabletLeft()), this, SLOT(resetTabletStatus()));
+  ret = ret &&
+        connect(app, SIGNAL(tabletLeft()), this, SLOT(resetTabletStatus()));
 
   if (m_stopMotion) {
-      ret = ret && connect(m_stopMotion, SIGNAL(newLiveViewImageReady()), this,
-            SLOT(onNewStopMotionImageReady()));
-      ret = ret && connect(m_stopMotion, SIGNAL(liveViewStopped()), this,
-            SLOT(onStopMotionLiveViewStopped()));
+    ret = ret && connect(m_stopMotion, SIGNAL(newLiveViewImageReady()), this,
+                         SLOT(onNewStopMotionImageReady()));
+    ret = ret && connect(m_stopMotion, SIGNAL(liveViewStopped()), this,
+                         SLOT(onStopMotionLiveViewStopped()));
   }
   assert(ret);
 
@@ -1181,23 +1188,23 @@ void SceneViewer::onStopMotionLiveViewStopped() {
 
 //-----------------------------------------------------------------------------
 
-void SceneViewer::onPreferenceChanged(const QString& prefName) {
-    if (prefName == "ColorCalibration") {
-        if (Preferences::instance()->isColorCalibrationEnabled()) {
-            makeCurrent();
-            if (!m_lutCalibrator)
-                m_lutCalibrator = new LutCalibrator();
-            else
-                m_lutCalibrator->cleanup();
-            m_lutCalibrator->initialize();
-            connect(context(), SIGNAL(aboutToBeDestroyed()), this,
-                SLOT(onContextAboutToBeDestroyed()));
-            if (m_lutCalibrator->isValid() && !m_fbo)
-                m_fbo = new QOpenGLFramebufferObject(width(), height());
-            doneCurrent();
-        }
-        update();
+void SceneViewer::onPreferenceChanged(const QString &prefName) {
+  if (prefName == "ColorCalibration") {
+    if (Preferences::instance()->isColorCalibrationEnabled()) {
+      makeCurrent();
+      if (!m_lutCalibrator)
+        m_lutCalibrator = new LutCalibrator();
+      else
+        m_lutCalibrator->cleanup();
+      m_lutCalibrator->initialize();
+      connect(context(), SIGNAL(aboutToBeDestroyed()), this,
+              SLOT(onContextAboutToBeDestroyed()));
+      if (m_lutCalibrator->isValid() && !m_fbo)
+        m_fbo = new QOpenGLFramebufferObject(width(), height());
+      doneCurrent();
     }
+    update();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -2086,10 +2093,10 @@ void SceneViewer::drawScene() {
 
     if (app->getCurrentFrame()->isEditingLevel()) {
       Stage::visitSingleLevel(painter, app->getCurrentLevel()->getLevel(),
-                   app->getCurrentFrame()->getFid(),
-                   app->getCurrentOnionSkin()->getOnionSkinMask(),
-                   frameHandle->isPlaying(), useGuidedDrawing, guidedBackStroke,
-                   guidedFrontStroke);
+                              app->getCurrentFrame()->getFid(),
+                              app->getCurrentOnionSkin()->getOnionSkinMask(),
+                              frameHandle->isPlaying(), useGuidedDrawing,
+                              guidedBackStroke, guidedFrontStroke);
     } else {
       std::pair<TXsheet *, int> xr;
       int xsheetLevel = 0;
@@ -3119,8 +3126,8 @@ int SceneViewer::posToRow(const TPointD &p, double distance,
 
   if (app->getCurrentFrame()->isEditingLevel()) {
     Stage::visitSingleLevel(picker, app->getCurrentLevel()->getLevel(),
-                 app->getCurrentFrame()->getFid(), osm,
-                 app->getCurrentFrame()->isPlaying(), false);
+                            app->getCurrentFrame()->getFid(), osm,
+                            app->getCurrentFrame()->isPlaying(), false);
   } else {
     ToonzScene *scene      = app->getCurrentScene()->getScene();
     TXsheet *xsh           = app->getCurrentXsheet()->getXsheet();

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -89,7 +89,11 @@
 
 #include "sceneviewer.h"
 
-TEnv::IntVar ShowPerspectiveGrids("ShowPerspectiveGrids", 1);
+//TEnv::IntVar ShowPerspectiveGrids("ShowPerspectiveGrids", 1);
+TEnv::IntVar CameraStandUseFxOrdering("CameraStandUseFxOrdering", 0);
+TEnv::IntVar CameraStandShowMattes("CameraStandShowMattes", 0);
+TEnv::IntVar CameraViewUseFxOrdering("CameraViewUseFxOrdering", 0);
+TEnv::IntVar CameraViewShowMattes("CameraViewShowMattes", 0);
 
 void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
                 double pixelSize);
@@ -2007,8 +2011,6 @@ void SceneViewer::drawScene() {
     args.m_guidedFrontStroke      = guidedFrontStroke;
     args.m_guidedBackStroke       = guidedBackStroke;
 
-    // args.m_currentFrameId = app->getCurrentFrame()->getFid();
-
     if (m_stopMotion->m_alwaysUseLiveViewImages &&
         m_stopMotion->m_liveViewStatus > 0 &&
         frame != m_stopMotion->getXSheetFrameNumber() - 1 &&
@@ -2024,8 +2026,6 @@ void SceneViewer::drawScene() {
         smPlayer.m_sl         = m_stopMotion->m_sl;
         args.m_liveViewImage  = static_cast<TRasterImageP>(image);
         args.m_liveViewPlayer = smPlayer;
-        // painter.onRasterImage(static_cast<TRasterImageP>(image).getPointer(),
-        //                      smPlayer);
       }
     }
     if (  //! m_stopMotion->m_drawBeneathLevels &&
@@ -2041,8 +2041,6 @@ void SceneViewer::drawScene() {
         smPlayer.m_sl       = m_stopMotion->m_sl;
         args.m_lineupImage  = m_stopMotionLineUpImage;
         args.m_lineupPlayer = smPlayer;
-        // painter.onRasterImage(m_stopMotionLineUpImage.getPointer(),
-        // smPlayer);
       }
       if (m_hasStopMotionImage) {
         Stage::Player smPlayer;
@@ -2059,7 +2057,6 @@ void SceneViewer::drawScene() {
         smPlayer.m_sl      = m_stopMotion->m_sl;
         args.m_liveViewImage  = m_stopMotionImage;
         args.m_liveViewPlayer = smPlayer;
-        // painter.onRasterImage(m_stopMotionImage.getPointer(), smPlayer);
       }
     }
 
@@ -2092,7 +2089,7 @@ void SceneViewer::drawScene() {
     TFrameHandle *frameHandle = TApp::instance()->getCurrentFrame();
 
     if (app->getCurrentFrame()->isEditingLevel()) {
-      Stage::visitSingleLevel(painter, app->getCurrentLevel()->getLevel(),
+      Stage::visit(painter, app->getCurrentLevel()->getLevel(),
                               app->getCurrentFrame()->getFid(),
                               app->getCurrentOnionSkin()->getOnionSkinMask(),
                               frameHandle->isPlaying(), useGuidedDrawing,
@@ -2123,6 +2120,7 @@ void SceneViewer::drawScene() {
       args.m_isGuidedDrawingEnabled = useGuidedDrawing;
       args.m_guidedFrontStroke      = guidedFrontStroke;
       args.m_guidedBackStroke       = guidedBackStroke;
+      args.m_useFxVisibility = CameraStandUseFxOrdering == 1 ? true : false;
 
       if (m_stopMotion->m_alwaysUseLiveViewImages &&
           m_stopMotion->m_liveViewStatus > 0 &&
@@ -2139,14 +2137,9 @@ void SceneViewer::drawScene() {
           smPlayer.m_sl        = m_stopMotion->m_sl;
           args.m_liveViewImage = static_cast<TRasterImageP>(image);
           args.m_liveViewPlayer = smPlayer;
-          // painter.onRasterImage(static_cast<TRasterImageP>(image).getPointer(),
-          //                      smPlayer);
         }
       }
-      if (  //! m_stopMotion->m_drawBeneathLevels &&
-          m_stopMotion->m_liveViewStatus == 2 &&
-          (  //! frameHandle->isPlaying() ||
-              frame == m_stopMotion->getXSheetFrameNumber() - 1)) {
+      if (  m_stopMotion->m_liveViewStatus == 2 && frame == m_stopMotion->getXSheetFrameNumber() - 1) {
         if (m_hasStopMotionLineUpImage && m_stopMotion->m_showLineUpImage) {
           Stage::Player smPlayer;
           double dpiX, dpiY;
@@ -2156,8 +2149,6 @@ void SceneViewer::drawScene() {
           smPlayer.m_sl       = m_stopMotion->m_sl;
           args.m_lineupImage  = m_stopMotionLineUpImage;
           args.m_lineupPlayer = smPlayer;
-          // painter.onRasterImage(m_stopMotionLineUpImage.getPointer(),
-          // smPlayer);
         }
         if (m_hasStopMotionImage) {
           Stage::Player smPlayer;
@@ -2175,7 +2166,6 @@ void SceneViewer::drawScene() {
           smPlayer.m_sl         = m_stopMotion->m_sl;
           args.m_liveViewImage  = m_stopMotionImage;
           args.m_liveViewPlayer = smPlayer;
-          // painter.onRasterImage(m_stopMotionImage.getPointer(), smPlayer);
         }
       }
       Stage::visit(painter, args);
@@ -3125,7 +3115,7 @@ int SceneViewer::posToRow(const TPointD &p, double distance,
   picker.setDistance(distance);
 
   if (app->getCurrentFrame()->isEditingLevel()) {
-    Stage::visitSingleLevel(picker, app->getCurrentLevel()->getLevel(),
+    Stage::visit(picker, app->getCurrentLevel()->getLevel(),
                             app->getCurrentFrame()->getFid(), osm,
                             app->getCurrentFrame()->isPlaying(), false);
   } else {

--- a/toonz/sources/toonz/viewerpane.cpp
+++ b/toonz/sources/toonz/viewerpane.cpp
@@ -426,7 +426,7 @@ void SceneViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
 
   TPanelTitleBarButtonSet *viewModeButtonSet;
   m_referenceModeBs = viewModeButtonSet = new TPanelTitleBarButtonSet();
-  int x                                 = -272;
+  int x                                 = -282;
   int iconWidth                         = 20;
   TPanelTitleBarButton *button;
 
@@ -480,10 +480,18 @@ void SceneViewerPanel::initializeTitleBar(TPanelTitleBar *titleBar) {
   button->setButtonSet(viewModeButtonSet, SceneViewer::NORMAL_REFERENCE);
   button->setPressed(true);
 
+  TPanelTitleBarButtonForCamStandView* camStandOptionsButton = new TPanelTitleBarButtonForCamStandView(
+      titleBar, getIconThemePath("actions/9/pane_more.svg"));
+  camStandOptionsButton->setToolTip(tr("Camera Stand View Options"));
+  x += 1 + iconWidth;
+  titleBar->add(QPoint(x, 0), camStandOptionsButton);
+  connect(camStandOptionsButton, &TPanelTitleBarButtonForCamStandView::updateViewer,
+      [=]() { m_sceneViewer->update(); });
+
   button = new TPanelTitleBarButton(titleBar,
                                     getIconThemePath("actions/20/pane_3d.svg"));
   button->setToolTip(tr("3D View"));
-  x += +1 + iconWidth;
+  x += 10;
   titleBar->add(QPoint(x, 0), button);
   button->setButtonSet(viewModeButtonSet, SceneViewer::CAMERA3D_REFERENCE);
 

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2807,7 +2807,8 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       //      new QAction(tr("Temporary Mask (Not in final render)"), this);
       //  setMask->setCheckable(true);
       //  setMask->setChecked(xsh->getColumn(col)->isMask());
-      //  setMask->setToolTip(tr("Only Toonz Vector levels can be used as masks. \n Masks don't"
+      //  setMask->setToolTip(tr("Only Toonz Vector levels can be used as masks.
+      //  \n Masks don't"
       //      "show up in final renders."));
       //  bool ret = true;
       //  ret      = ret &&

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -2801,20 +2801,20 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       menu.addAction(cmdManager->getAction(MI_ReplaceLevel));
       menu.addAction(cmdManager->getAction(MI_ReplaceParentDirectory));
 
-       if (true) {
-        menu.addSeparator();
-        QAction *setMask =
-            new QAction(tr("Temporary Mask (Not in final render)"), this);
-        setMask->setCheckable(true);
-        setMask->setChecked(xsh->getColumn(col)->isMask());
-        setMask->setToolTip(tr("Only Toonz Vector levels can be used as masks. \n Masks don't"
-            "show up in final renders."));
-        bool ret = true;
-        ret      = ret &&
-              connect(setMask, &QAction::toggled, [=]() { onSetMask(col); });
-        assert(ret);
-        menu.addAction(setMask);
-      }
+      // if (containsVectorLevel(col)) {
+      //  menu.addSeparator();
+      //  QAction *setMask =
+      //      new QAction(tr("Temporary Mask (Not in final render)"), this);
+      //  setMask->setCheckable(true);
+      //  setMask->setChecked(xsh->getColumn(col)->isMask());
+      //  setMask->setToolTip(tr("Only Toonz Vector levels can be used as masks. \n Masks don't"
+      //      "show up in final renders."));
+      //  bool ret = true;
+      //  ret      = ret &&
+      //        connect(setMask, &QAction::toggled, [=]() { onSetMask(col); });
+      //  assert(ret);
+      //  menu.addAction(setMask);
+      //}
     }
   }
 

--- a/toonz/sources/toonz/xshcolumnviewer.cpp
+++ b/toonz/sources/toonz/xshcolumnviewer.cpp
@@ -174,7 +174,7 @@ public:
     TXshColumn::ColumnType type = column->getColumnType();
     if (type != TXshColumn::eLevelType) return;
 
-    if (containsVectorLevel(m_col)) {
+    if (true || containsVectorLevel(m_col)) {
       column->setIsMask(!m_isMask);
       TApp::instance()->getCurrentScene()->notifySceneChanged();
       TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
@@ -2801,22 +2801,20 @@ void ColumnArea::contextMenuEvent(QContextMenuEvent *event) {
       menu.addAction(cmdManager->getAction(MI_ReplaceLevel));
       menu.addAction(cmdManager->getAction(MI_ReplaceParentDirectory));
 
-      // if (containsVectorLevel(col)) {
-      //  menu.addSeparator();
-      //  QAction *setMask =
-      //      new QAction(tr("Temporary Mask (Not in final render)"), this);
-      //  setMask->setCheckable(true);
-      //  setMask->setChecked(xsh->getColumn(col)->isMask());
-      //  setMask->setToolTip(
-      //      tr("Only Toonz Vector levels can be used as masks. \n Masks don't
-      //      "
-      //         "show up in final renders."));
-      //  bool ret = true;
-      //  ret      = ret &&
-      //        connect(setMask, &QAction::toggled, [=]() { onSetMask(col); });
-      //  assert(ret);
-      //  menu.addAction(setMask);
-      //}
+       if (true) {
+        menu.addSeparator();
+        QAction *setMask =
+            new QAction(tr("Temporary Mask (Not in final render)"), this);
+        setMask->setCheckable(true);
+        setMask->setChecked(xsh->getColumn(col)->isMask());
+        setMask->setToolTip(tr("Only Toonz Vector levels can be used as masks. \n Masks don't"
+            "show up in final renders."));
+        bool ret = true;
+        ret      = ret &&
+              connect(setMask, &QAction::toggled, [=]() { onSetMask(col); });
+        assert(ret);
+        menu.addAction(setMask);
+      }
     }
   }
 

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -161,11 +161,10 @@ public:
 
 //=============================================================================
 /*! The StageBuilder class finds and provides data for frame visualization.
-\n	The class contains a \b PlayerSet, a vector of player, of all
+	The class contains a PlayerSet, a vector of player, of all
 necessary information.
 */
-// Tutto cio che riguarda una "colonna maschera" non e' utilizzato in TOONZ ma
-// in TAB Pro.
+// Anything concerning a "mask column" is not used in TOONZ but in TAB Pro.
 //=============================================================================
 
 class StageBuilder {
@@ -221,29 +220,25 @@ public:
   StageBuilder();
   virtual ~StageBuilder();
 
-  /*! Add in \b players vector information about specify cell.
-  \n	Analyze cell in row \b row and column \b col of xsheet \b xsh. If level
-                  containing this cell is a simple level, \b TXshSimpleLevel,
-  create a Pleyer
-                  object with information of the cell. Else if level is a child
-  level,
-                  \b TXshChildLevel, recall \b addFrame().
+  /*! Add in players vector information about specify cell.
+  	Analyze cell in row row and column col of xsheet xsh. If level
+                  containing this cell is a simple level, TXshSimpleLevel,
+  create a Pleyer object with information of the cell. 
+  Else if level is a child level, TXshChildLevel, recall addFrame().
   */
   void addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh, int row,
                int col, int level, int subSheetColIndex = -1);
 
   /*! Verify if onion-skin is active and recall \b addCell().
-  \n	Compute the distance between each cell with active onion-skin and
-  current
-                  cell and recall \b addCell(). If onion-skin is not active
-  recall \b addCell()
-                  with argument current cell.
+  	Compute the distance between each cell with active onion-skin and
+  current cell and recall addCell(). If onion-skin is not active
+  recall addCell() with argument current cell.
   */
   void addCellWithOnionSkin(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
                             int row, int col, int level,
                             int subSheetColIndex = -1);
 
-  /*!Recall \b addCellWithOnionSkin() for each cell of row \b row.*/
+  /*!Recall addCellWithOnionSkin() for each cell of row row.*/
   // if subSheetColIndex >= 0 it means that this function is called on visiting
   // subxsheet images and it indicates the column index in the current (parent)
   // xsheet. Checking options (like Fill Check etc.) will then valuate this
@@ -252,16 +247,14 @@ public:
                 int level, bool includeUnvisible, bool checkPreviewVisibility,
                 int subSheetColIndex = -1);
 
-  /*! Add in \b players vector information about \b level cell with \b TFrameId
-  \b fid.
-  \n	Compute information for all cell with active onion-skin, if onion-skin
-  is not active
-                  compute information only for current cell.
+  /*! Add in players vector information about \b level cell with \b TFrameId
+  fid. Compute information for all cell with active onion-skin, if onion-skin
+  is not active compute information only for current cell.
   */
   void addSimpleLevelFrame(PlayerSet &players, TXshSimpleLevel *level,
                            const TFrameId &fid);
 
-  /*! Recall \b visitor.onImage(player) for each \b player contained in \b
+  /*! Recall visitor.onImage(player) for each player contained in 
    * players vector.
    */
   void visit(PlayerSet &players, Visitor &visitor, bool isPlaying = false);
@@ -679,6 +672,7 @@ void StageBuilder::addFrame(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
     bool isMask        = false;
     if (column && !column->isEmpty()) {
       if (!column->isPreviewVisible() && checkPreviewVisibility) continue;
+      // if (!column->isRendered() || column->isControl()) continue;
       if (column->isCamstandVisible() ||
           includeUnvisible)  // se l'"occhietto" non e' chiuso
       {
@@ -838,10 +832,10 @@ void StageBuilder::visit(PlayerSet &players, Visitor &visitor, bool isPlaying) {
   for (; h < m; h++) {
     Player &player = players[h];
     unsigned int i = 0;
-    // vale solo per TAB pro
+
     for (; i < masks.size() && i < player.m_masks.size(); i++)
       if (masks[i] != player.m_masks[i]) break;
-    // vale solo per TAB pro
+
     if (i < masks.size() || i < player.m_masks.size()) {
       while (i < masks.size()) {
         masks.pop_back();
@@ -883,7 +877,7 @@ void StageBuilder::visit(PlayerSet &players, Visitor &visitor, bool isPlaying) {
       visitor.onRasterImage(m_liveViewImage.getPointer(), m_liveViewPlayer);
     }
   }
-  // vale solo per TAB pro
+
   for (h = 0; h < (int)masks.size(); h++) visitor.disableMask();
 }
 
@@ -961,7 +955,7 @@ void Stage::visit(Visitor &visitor, ToonzScene *scene, TXsheet *xsh, int row) {
    StageBuilder::addSimpleLevelFrame()
                 and \b StageBuilder::visit().
 */
-void Stage::visit(Visitor &visitor, TXshSimpleLevel *level, const TFrameId &fid,
+void Stage::visitSimpleLevel(Visitor &visitor, TXshSimpleLevel *level, const TFrameId &fid,
                   const OnionSkinMask &osm, bool isPlaying,
                   int isGuidedDrawingEnabled, int guidedBackStroke,
                   int guidedFrontStroke) {
@@ -985,11 +979,11 @@ void Stage::visit(Visitor &visitor, TXshSimpleLevel *level, const TFrameId &fid,
 
 //-----------------------------------------------------------------------------
 
-void Stage::visit(Visitor &visitor, TXshLevel *level, const TFrameId &fid,
+void Stage::visitSingleLevel (Visitor& visitor, TXshLevel* level, const TFrameId& fid,
                   const OnionSkinMask &osm, bool isPlaying,
                   double isGuidedDrawingEnabled, int guidedBackStroke,
                   int guidedFrontStroke) {
   if (level && level->getSimpleLevel())
-    visit(visitor, level->getSimpleLevel(), fid, osm, isPlaying,
+    visitSimpleLevel(visitor, level->getSimpleLevel(), fid, osm, isPlaying,
           (int)isGuidedDrawingEnabled, guidedBackStroke, guidedFrontStroke);
 }

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -73,13 +73,10 @@
 
 using namespace Stage;
 
-/*! \var Stage::inch
-                For historical reasons camera stand is defined in a coordinate
-   system in which
-                an inch is equal to 'Stage::inch' unit.
-                Pay attention: modify this value condition apparent line
-   thickness of
-                images .pli.
+/*! Stage::inch
+   For historical reasons camera stand is defined in a coordinate
+   system in which an inch is equal to 'Stage::inch' unit.
+   Pay attention: modify this value condition apparent line thickness of images .pli.
 */
 // const double Stage::inch = 53.33333;
 
@@ -449,13 +446,10 @@ TRasterP RasterPainter::getRaster(int index, QMatrix &matrix) {
 //-----------------------------------------------------------------------------
 
 /*! Make frame visualization.
-\n	If onon-skin is active, create a new raster with dimension containing
-all
-                frame with onion-skin; recall \b TRop::quickPut with argument
-each frame
-                with onion-skin and new raster. If onion-skin is not active
-recall
-                \b TRop::quickPut with argument current frame and new raster.
+If onon-skin is active, create a new raster with dimension containing
+all frame with onion-skin; recall \b TRop::quickPut with argument
+each frame with onion-skin and new raster. If onion-skin is not active
+recall TRop::quickPut with argument current frame and new raster.
 */
 
 namespace {
@@ -700,6 +694,8 @@ void RasterPainter::flushRasterImages() {
 \n	Draw in painter mode just raster image in m_nodes.
 \n  Onon-skin or channel mode are not considered.
 */
+
+// This doesn't seem to be used anywhere.
 void RasterPainter::drawRasterImages(QPainter &p, QPolygon cameraPol) {
   if (m_nodes.empty()) return;
 
@@ -994,7 +990,7 @@ void RasterPainter::onVectorImage(TVectorImage *vi,
 
 //-----------------------------------------------------
 
-/*! Create a \b Node and put it in \b m_nodes.
+/*! Create a Node and put it in m_nodes.
 */
 void RasterPainter::onRasterImage(TRasterImage *ri,
                                   const Stage::Player &player) {

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -380,24 +380,23 @@ RasterPainter::RasterPainter(const TDimension &dim, const TAffine &viewAff,
 
 //-----------------------------------------------------------------------------
 
-//! Utilizzato solo per TAB Pro
 void RasterPainter::beginMask() {
-  flushRasterImages();  // per evitare che venga fatto dopo il beginMask
+  flushRasterImages();  // to prevent it from being done after the beginMask
   ++m_maskLevel;
   TStencilControl::instance()->beginMask();
 }
-//! Utilizzato solo per TAB Pro
+
 void RasterPainter::endMask() {
-  flushRasterImages();  // se ci sono delle immagini raster nella maschera
-                        // devono uscire ora
+  flushRasterImages();  // if there are raster images in the mask
+  // they have to get out now
   --m_maskLevel;
   TStencilControl::instance()->endMask();
 }
-//! Utilizzato solo per TAB Pro
+
 void RasterPainter::enableMask() {
   TStencilControl::instance()->enableMask(TStencilControl::SHOW_INSIDE);
 }
-//! Utilizzato solo per TAB Pro
+
 void RasterPainter::disableMask() {
   flushRasterImages();  // se ci sono delle immagini raster mascherate devono
                         // uscire ora

--- a/toonz/sources/toonzlib/stagevisitor.cpp
+++ b/toonz/sources/toonzlib/stagevisitor.cpp
@@ -76,7 +76,8 @@ using namespace Stage;
 /*! Stage::inch
    For historical reasons camera stand is defined in a coordinate
    system in which an inch is equal to 'Stage::inch' unit.
-   Pay attention: modify this value condition apparent line thickness of images .pli.
+   Pay attention: modify this value condition apparent line thickness of images
+   .pli.
 */
 // const double Stage::inch = 53.33333;
 


### PR DESCRIPTION
This is the first step toward bringing in live matte fx.  

This gives an option in a drop down next to the camstand and camera view buttons to draw the viewer based on the hierarchy of the fx schematic.

This will allow fx like over fx to change the drawing order shown in the viewer.

Eventually this will also allow matte in/out nodes to do live matting.

This isn't even test worthy right now, but I am making this PR to get comments and feedback about the desired functionality of this.

It does currently build the viewer based on the schematic, but does not take into account any actual fx.  But if a node is disconnected from the schematic, it will not show with this option on.

This will not become the new default and will always be an option.  Once it starts working with more fx, there could be a performance hit, so I want the current behavior to always be available.