### PR TITLE
Correct mac shortcuts and missing menu item

### DIFF
--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -622,6 +622,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(renderMenu, MI_SavePreviewedFrames);
   renderMenu->addSeparator();
   addMenuItem(renderMenu, MI_OutputSettings);
+  addMenuItem(renderMenu, MI_Render);
   addMenuItem(renderMenu, MI_SaveAndRender);
   renderMenu->addSeparator();
   addMenuItem(renderMenu, MI_FastRender);

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -131,26 +131,49 @@ void StatusBar::makeMap() {
   m_infoMap.insert({"T_BrushVector",
                     "Brush Tool: Draws in the work area freehand" + spacer +
                         "Shift - Straight Lines" + spacer +
+#ifdef MACOSX
+                        "Cmd - Straight Lines Snapped to Angles" + spacer +
+                        "Cmd + Opt - Add / Remove Vanishing Point" + spacer +
+                        "Opt - Draw to Vanishing Point" + spacer +
+                        "Hold Cmd + Shift - Toggle Snapping"});
+#else
                         "Control - Straight Lines Snapped to Angles" + spacer +
                         "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
                         "Alt - Draw to Vanishing Point" + spacer +
                         "Hold Ctrl + Shift - Toggle Snapping"});
+#endif
   m_infoMap.insert({"T_BrushSmartRaster",
                     "Brush Tool: Draws in the work area freehand" + spacer +
                         "Shift - Straight Lines" + spacer +
+#ifdef MACOSX
+                        "Cmd - Straight Lines Snapped to Angles" + spacer +
+                        "Cmd + Opt - Add / Remove Vanishing Point" + spacer +
+                        "Opt - Draw to Vanishing Point"});
+#else
                         "Control - Straight Lines Snapped to Angles" + spacer +
                         "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
                         "Alt - Draw to Vanishing Point"});
+#endif
   m_infoMap.insert({"T_BrushRaster",
                     "Brush Tool: Draws in the work area freehand" + spacer +
                         "Shift - Straight Lines" + spacer +
+#ifdef MACOSX
+                        "Cmd - Straight Lines Snapped to Angles" + spacer +
+                        "Cmd + Opt - Add / Remove Vanishing Point" + spacer +
+                        "Opt - Draw to Vanishing Point"});
+#else
                         "Control - Straight Lines Snapped to Angles" + spacer +
                         "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
                         "Alt - Draw to Vanishing Point"});
+#endif
   m_infoMap.insert({"T_Geometric", "Geometry Tool: Draws geometric shapes"});
   m_infoMap.insert({ "T_GeometricVector", "Geometry Tool: Draws geometric shapes" +
                                        spacer +
+#ifdef MACOSX
+                        "Hold Cmd + Shift - Toggle Snapping" });
+#else
                                        "Hold Ctrl + Shift - Toggle Snapping" });
+#endif
   m_infoMap.insert({"T_Type", "Type Tool: Adds text"});
   m_infoMap.insert(
       {"T_PaintBrush",


### PR DESCRIPTION
For Tahoma on macOS, we use Cmd instead of Ctrl and Opt instead of Alt. This fixes the display of those shortcuts in the status bar on macOS.