### PR TITLE
Block fixed with panels on dock and undock

### DIFF
--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -95,8 +95,8 @@ public:
   QLayoutItem *takeAt(int) override;
   void setGeometry(const QRect &rect) override;
 
-  void update();        // Re-applies partition found
-  void redistribute();  // Calculates partition
+  void update();                                   // Re-applies partition found
+  void redistribute(bool allowFixedItems = true);  // Calculates partition
   void applyTransform(const QTransform &transform);  // Applies tranformation to
                                                      // known parition - Da
                                                      // rimuovere, non serve...


### PR DESCRIPTION
fixes #325 
This prevents panels from being fixed width if an item is docked or undocked.

@artisteacher 
Would you mind testing this on Mac to see if it breaks anything?  It's a pretty straight-forward fix, so it should be fine, but I'd like to make sure.