### PR TITLE
Attempt at fixing mac record audio crash. . .

### DIFF
--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -28,6 +28,14 @@
 #include "tpixelutils.h"
 #include "iocommand.h"
 
+#ifdef MACOSX
+
+#include <AudioToolbox/AudioToolbox.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <AVFoundation/AVFoundation.h>
+
+#endif
+
 // Qt includes
 #include <QMainWindow>
 #include <QAudio>

--- a/toonz/sources/toonz/audiorecordingpopup.cpp
+++ b/toonz/sources/toonz/audiorecordingpopup.cpp
@@ -286,7 +286,9 @@ void AudioRecordingPopup::onRecordButtonPressed() {
 //-----------------------------------------------------------------------------
 
 #ifdef MACOSX
-void AudioRecordingPopup::dealWithMicrophone() {
+// based on
+// https://stackoverflow.com/questions/56084303/opencv-command-line-app-cant-access-camera-under-macos-mojave
+bool AudioRecordingPopup::dealWithMicrophone() {
   AVAuthorizationStatus st =
       [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
   if (st == AVAuthorizationStatusAuthorized) {

--- a/toonz/sources/toonz/audiorecordingpopup.h
+++ b/toonz/sources/toonz/audiorecordingpopup.h
@@ -67,6 +67,9 @@ protected:
   void hideEvent(QHideEvent *event);
   void makePaths();
   void resetEverything();
+#ifdef MACOSX
+  bool dealWithMicrophone();
+#endif
 
 private slots:
   void onRecordButtonPressed();


### PR DESCRIPTION
closes #158 hopefully

This should ask for permission before accessing the mic.
It is probably missing some #include directives.

I can't test it, but hopefully this is the start of getting things working.

@artisteacher When you get the chance, could you take a look?  My guess is that it will throw missing include errors.  But I don't know what to include yet.