### PR TITLE
Change what's new link to manual page

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1067,7 +1067,7 @@ void MainWindow::onSupportTahoma2D() {
 
 void MainWindow::onOpenWhatsNew() {
   QDesktopServices::openUrl(
-      QUrl(tr("https://github.com/turtletooth/tahoma2d/releases/latest")));
+      QUrl(tr("https://tahoma.readthedocs.io/en/latest/whats_new.html")));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The current link going to GitHub isn't actually descriptive of what's new. The manual's page is much more detailed.