### PR TITLE
Centralize user preference and configuration files

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -158,8 +158,8 @@ public:
         getSystemVarPathValue(getSystemVarPrefix() + "PROFILES");
     if (profilesDir == TFilePath())
       profilesDir = getStuffDir() + systemPathMap.at("PROFILES");
-    m_envFile =
-        profilesDir + "env" + (TSystem::getUserName().toStdString() + ".env");
+    m_envFile = profilesDir + "users" + TSystem::getUserName().toStdString() +
+                "env.ini";
   }
 
   void init() {

--- a/toonz/sources/include/toonz/toonzfolders.h
+++ b/toonz/sources/include/toonz/toonzfolders.h
@@ -44,6 +44,8 @@ DVAPI TFilePath getLibraryFolder();
 DVAPI TFilePath getReslistPath(bool forCleanup);
 DVAPI TFilePath getCacheRootFolder();
 DVAPI TFilePath getProfileFolder();
+
+DVAPI TFilePath getMyReslistPath(bool forCleanup);
 };
 
 class DVAPI FolderListenerManager {  // singleton

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -26,6 +26,7 @@
 #include "toonz/palettecontroller.h"
 #include "toonz/mypaintbrushstyle.h"
 #include "toonz/preferences.h"
+#include "toonz/toonzfolders.h"
 
 // TnzCore includes
 #include "tgl.h"
@@ -38,6 +39,7 @@
 #include "tstroke.h"
 #include "timagecache.h"
 #include "tpixelutils.h"
+#include "tsystem.h"
 
 // Qt includes
 #include <QCoreApplication>  // Qt translation support
@@ -925,7 +927,7 @@ void FullColorBrushTool::initPresets() {
   if (!m_presetsLoaded) {
     // If necessary, load the presets from file
     m_presetsLoaded = true;
-    m_presetsManager.load(TEnv::getConfigDir() + "brush_raster.txt");
+    m_presetsManager.load(ToonzFolder::getMyModuleDir() + "brush_raster.txt");
   }
 
   // Rebuild the presets property entries

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -30,6 +30,7 @@
 #include "toonz/preferences.h"
 #include "toonz/tpalettehandle.h"
 #include "toonz/mypaintbrushstyle.h"
+#include "toonz/toonzfolders.h"
 
 // TnzCore includes
 #include "tstream.h"
@@ -38,6 +39,7 @@
 #include "tenv.h"
 #include "tregion.h"
 #include "tinbetween.h"
+#include "tsystem.h"
 
 #include "tgl.h"
 #include "trop.h"
@@ -2392,7 +2394,8 @@ void ToonzRasterBrushTool::initPresets() {
   if (!m_presetsLoaded) {
     // If necessary, load the presets from file
     m_presetsLoaded = true;
-    m_presetsManager.load(TEnv::getConfigDir() + "brush_toonzraster.txt");
+    m_presetsManager.load(ToonzFolder::getMyModuleDir() +
+                          "brush_smartraster.txt");
   }
 
   // Rebuild the presets property entries
@@ -2728,6 +2731,8 @@ void BrushPresetManager::load(const TFilePath &fp) {
 //------------------------------------------------------------------
 
 void BrushPresetManager::save() {
+  TSystem::touchParentDir(m_fp);
+
   TOStream os(m_fp);
 
   os.openChild("version");

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -29,6 +29,7 @@
 #include "toonz/stage2.h"
 #include "toonz/preferences.h"
 #include "toonz/tonionskinmaskhandle.h"
+#include "toonz/toonzfolders.h"
 
 // TnzCore includes
 #include "tstream.h"
@@ -37,6 +38,7 @@
 #include "tenv.h"
 #include "tregion.h"
 #include "tinbetween.h"
+#include "tsystem.h"
 
 #include "tgl.h"
 #include "trop.h"
@@ -2063,7 +2065,7 @@ void ToonzVectorBrushTool::initPresets() {
   if (!m_presetsLoaded) {
     // If necessary, load the presets from file
     m_presetsLoaded = true;
-    m_presetsManager.load(TEnv::getConfigDir() + "brush_vector.txt");
+    m_presetsManager.load(ToonzFolder::getMyModuleDir() + "brush_vector.txt");
   }
 
   // Rebuild the presets property entries

--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -83,7 +83,8 @@ CameraSettingsPopup::CameraSettingsPopup()
   m_nameFld              = new LineEdit();
   m_cameraSettingsWidget = new CameraSettingsWidget();
 
-  m_cameraSettingsWidget->setPresetListFile(ToonzFolder::getReslistPath(false));
+  m_cameraSettingsWidget->setPresetListFile(
+      ToonzFolder::getMyReslistPath(false));
 
   //---- layout
   QVBoxLayout *mainLay = new QVBoxLayout();

--- a/toonz/sources/toonz/cleanupsettingspane.cpp
+++ b/toonz/sources/toonz/cleanupsettingspane.cpp
@@ -132,7 +132,7 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
   m_rotateOm->addItems(rotate);
   // Camera
   cameraFrame->setObjectName("CleanupSettingsFrame");
-  m_cameraWidget->setCameraPresetListFile(ToonzFolder::getReslistPath(true));
+  m_cameraWidget->setCameraPresetListFile(ToonzFolder::getMyReslistPath(true));
   // LineProcessing
   lineProcFrame->setObjectName("CleanupSettingsFrame");
   QStringList items;
@@ -267,9 +267,9 @@ CleanupSettingsPane::CleanupSettingsPane(QWidget *parent)
   bool ret = true;
   ret      = ret && connect(m_autocenterBox, SIGNAL(clicked(bool)),
                        SLOT(onGenericSettingsChange()));
-  ret      = ret && connect(m_pegHolesOm, SIGNAL(activated(int)),
+  ret = ret && connect(m_pegHolesOm, SIGNAL(activated(int)),
                        SLOT(onGenericSettingsChange()));
-  ret      = ret && connect(m_fieldGuideOm, SIGNAL(activated(int)),
+  ret = ret && connect(m_fieldGuideOm, SIGNAL(activated(int)),
                        SLOT(onGenericSettingsChange()));
 
   ret = ret && connect(m_rotateOm, SIGNAL(activated(int)),
@@ -321,7 +321,7 @@ void CleanupSettingsPane::showEvent(QShowEvent *se) {
     bool ret = true;
     ret      = ret && connect(model, SIGNAL(imageSwitched()), this,
                          SLOT(onImageSwitched()));
-    ret      = ret && connect(model, SIGNAL(modelChanged(bool)), this,
+    ret = ret && connect(model, SIGNAL(modelChanged(bool)), this,
                          SLOT(updateGui(bool)));
     ret = ret && connect(model, SIGNAL(clnLoaded()), this, SLOT(onClnLoaded()));
     assert(ret);
@@ -355,9 +355,9 @@ void CleanupSettingsPane::hideEvent(QHideEvent *he) {
     bool ret = true;
     ret      = ret && disconnect(model, SIGNAL(imageSwitched()), this,
                             SLOT(onImageSwitched()));
-    ret      = ret && disconnect(model, SIGNAL(modelChanged(bool)), this,
+    ret = ret && disconnect(model, SIGNAL(modelChanged(bool)), this,
                             SLOT(updateGui(bool)));
-    ret      = ret &&
+    ret = ret &&
           disconnect(model, SIGNAL(clnLoaded()), this, SLOT(onClnLoaded()));
     assert(ret);
   }

--- a/toonz/sources/toonz/cleanupsettingspopup.cpp
+++ b/toonz/sources/toonz/cleanupsettingspopup.cpp
@@ -585,7 +585,7 @@ CleanupSettings::CleanupSettings(QWidget *parent)
   m_cameraTab = new CameraTab;
   scrollArea->setWidget(m_cameraTab);
 
-  m_cameraTab->setCameraPresetListFile(ToonzFolder::getReslistPath(true));
+  m_cameraTab->setCameraPresetListFile(ToonzFolder::getMyReslistPath(true));
 
   //  Swatch
 

--- a/toonz/sources/toonz/history.cpp
+++ b/toonz/sources/toonz/history.cpp
@@ -10,8 +10,7 @@
 //#include <fstream.h>
 
 inline TFilePath getHistoryFile() {
-  return TEnv::getConfigDir() +
-         (TSystem::getUserName().toStdString() + "_history.txt");
+  return ToonzFolder::getMyModuleDir() + L"file_history.txt";
 }
 
 std::string History::Day::getDate() const {

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -27,6 +27,7 @@
 #include "toutputproperties.h"
 #include "toonz/tcamera.h"
 #include "toonz/boardsettings.h"
+#include "toonz/toonzfolders.h"
 
 // TnzBase includes
 #include "trasterfx.h"
@@ -221,12 +222,12 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
   QPushButton *addPresetButton            = NULL;
   QPushButton *removePresetButton         = NULL;
 
-  m_dominantFieldOm = 0;
-  m_renderButton    = new QPushButton(tr("Render"), this);
-  m_saveAndRenderButton    = new QPushButton(tr("Save and Render"), this);
+  m_dominantFieldOm     = 0;
+  m_renderButton        = new QPushButton(tr("Render"), this);
+  m_saveAndRenderButton = new QPushButton(tr("Save and Render"), this);
   if (isPreview) {
-      m_renderButton->setText("Preview");
-      m_saveAndRenderButton->hide();
+    m_renderButton->setText("Preview");
+    m_saveAndRenderButton->hide();
   }
   if (!isPreview) {
     showOtherSettingsButton = new QPushButton("", this);
@@ -618,7 +619,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     advancedSettingsBox->setLayout(fileSetBoxLay);
     m_topLayout->addWidget(advancedSettingsBox, 0);
 
-    QHBoxLayout* renderButtonLayout = new QHBoxLayout(this);
+    QHBoxLayout *renderButtonLayout = new QHBoxLayout(this);
     renderButtonLayout->addWidget(m_renderButton);
     renderButtonLayout->addWidget(m_saveAndRenderButton);
     m_topLayout->addLayout(renderButtonLayout);
@@ -642,7 +643,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
   ret = ret && connect(m_renderButton, SIGNAL(pressed()), this,
                        SLOT(onRenderClicked()));
   ret = ret && connect(m_saveAndRenderButton, SIGNAL(pressed()), this,
-      SLOT(onSaveAndRenderClicked()));
+                       SLOT(onSaveAndRenderClicked()));
   ret = ret &&
         connect(m_outputCameraOm, SIGNAL(currentIndexChanged(const QString &)),
                 SLOT(onCameraChanged(const QString &)));
@@ -802,7 +803,7 @@ void OutputSettingsPopup::onRenderClicked() {
 //-----------------------------------------------------------------------------
 
 void OutputSettingsPopup::onSaveAndRenderClicked() {
-   CommandManager::instance()->execute("MI_SaveAndRender");
+  CommandManager::instance()->execute("MI_SaveAndRender");
 }
 
 //-----------------------------------------------------------------------------
@@ -1366,7 +1367,7 @@ void OutputSettingsPopup::onAddPresetButtonPressed() {
   if (!ok || qs.isEmpty()) return;
 
   if (!qs.endsWith(".txt")) qs.append(".txt");
-  TFilePath fp = TEnv::getConfigDir() + "outputpresets";
+  TFilePath fp = ToonzFolder::getMyModuleDir() + "outputpresets";
   if (!TFileStatus(fp).doesExist()) TSystem::mkDir(fp);
   fp = fp + qs.toStdString();
 
@@ -1459,7 +1460,7 @@ void OutputSettingsPopup::onAddPresetButtonPressed() {
 void OutputSettingsPopup::updatePresetComboItems() {
   m_presetCombo->clear();
   m_presetCombo->addItem(tr("<custom>"));
-  TFilePath folder = TEnv::getConfigDir() + "outputpresets";
+  TFilePath folder = ToonzFolder::getMyModuleDir() + "outputpresets";
 
   TFileStatus fs(folder);
   if (!fs.doesExist()) TSystem::mkDir(folder);
@@ -1508,7 +1509,7 @@ void OutputSettingsPopup::onRemovePresetButtonPressed() {
   if (ret == QMessageBox::Cancel) return;
 
   TFilePath fp =
-      TEnv::getConfigDir() + "outputpresets" +
+      ToonzFolder::getMyModuleDir() + "outputpresets" +
       QString("%1.txt").arg(m_presetCombo->currentText()).toStdString();
   if (TFileStatus(fp).doesExist()) TSystem::deleteFile(fp);
 
@@ -1523,7 +1524,7 @@ void OutputSettingsPopup::onRemovePresetButtonPressed() {
 void OutputSettingsPopup::onPresetSelected(const QString &str) {
   /*-- "<custom>"を選択したら何もせずreturn --*/
   if (m_presetCombo->currentIndex() == 0) return;
-  TFilePath fp = TEnv::getConfigDir() + "outputpresets" +
+  TFilePath fp = ToonzFolder::getMyModuleDir() + "outputpresets" +
                  QString("%1.txt").arg(str).toStdString();
   if (!TFileStatus(fp).doesExist()) {
     QMessageBox::warning(this, tr("Warning"),

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -635,7 +635,10 @@ void StartupPopup::onProjectChanged(int index) {
 void StartupPopup::loadPresetList() {
   m_presetCombo->clear();
   m_presetCombo->addItem("...");
-  m_presetListFile = ToonzFolder::getReslistPath(false).getQString();
+  m_presetListFile = ToonzFolder::getMyReslistPath(false).getQString();
+  if (!TFileStatus(TFilePath(m_presetListFile)).doesExist())
+    TSystem::copyFile(TFilePath(m_presetListFile),
+                      ToonzFolder::getReslistPath(false));
   QFile file(m_presetListFile);
   if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
     QTextStream in(&file);

--- a/toonz/sources/toonzlib/toonzfolders.cpp
+++ b/toonz/sources/toonzlib/toonzfolders.cpp
@@ -56,15 +56,15 @@ TFilePathSet ToonzFolder::getProjectsFolders() {
                     TEnv::getSystemPathMap().at("PROJECTS"));
   }
   if (documents) {
-    fps.push_back(getMyDocumentsPath() + "OpenToonz");
-    if (!TSystem::doesExistFileOrLevel(getMyDocumentsPath() + "OpenToonz")) {
-      TSystem::mkDir(getMyDocumentsPath() + "OpenToonz");
+    fps.push_back(getMyDocumentsPath() + "Tahoma2D");
+    if (!TSystem::doesExistFileOrLevel(getMyDocumentsPath() + "Tahoma2D")) {
+      TSystem::mkDir(getMyDocumentsPath() + "Tahoma2D");
     }
   }
   if (desktop) {
-    fps.push_back(getDesktopPath() + "OpenToonz");
-    if (!TSystem::doesExistFileOrLevel(getDesktopPath() + "OpenToonz")) {
-      TSystem::mkDir(getDesktopPath() + "OpenToonz");
+    fps.push_back(getDesktopPath() + "Tahoma2D");
+    if (!TSystem::doesExistFileOrLevel(getDesktopPath() + "Tahoma2D")) {
+      TSystem::mkDir(getDesktopPath() + "Tahoma2D");
     }
   }
   if (custom) {
@@ -131,14 +131,18 @@ TFilePath ToonzFolder::getReslistPath(bool forCleanup) {
   return getConfigDir() + (forCleanup ? "cleanupreslist.txt" : "reslist.txt");
 }
 
+TFilePath ToonzFolder::getMyReslistPath(bool forCleanup) {
+  return getMyModuleDir() + (forCleanup ? "cleanupreslist.txt" : "reslist.txt");
+}
+
 TFilePath ToonzFolder::getTemplateModuleDir() {
   // return getModulesDir() + getModuleName();
   return getModulesDir() + "settings";
 }
 
 TFilePath ToonzFolder::getMyModuleDir() {
-  TFilePath fp(getTemplateModuleDir());
-  return fp.withName(fp.getWideName() + L"." +
+  TFilePath fp(getProfileFolder());
+  return fp.withName(fp.getWideName() + L"/users/" +
                      TSystem::getUserName().toStdWString());
 }
 
@@ -167,11 +171,10 @@ TFilePath ToonzFolder::getTemplateRoomsDir() {
 
 TFilePath ToonzFolder::getMyRoomsDir() {
   // TFilePath fp(getTemplateRoomsDir());
-  TFilePath fp(getProfileFolder());
+  TFilePath fp(getMyModuleDir());
   return fp.withName(
-      fp.getWideName() + L"/layouts/personal/" +
-      Preferences::instance()->getCurrentRoomChoice().toStdWString() + L"." +
-      TSystem::getUserName().toStdWString());
+      fp.getWideName() + L"/layouts/" +
+      Preferences::instance()->getCurrentRoomChoice().toStdWString());
 }
 
 TFilePath ToonzFolder::getRoomsFile(TFilePath filename) {

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -29,6 +29,7 @@
 #include "tsystem.h"
 #include "tfilepath_io.h"
 #include "tutil.h"
+#include "tenv.h"
 
 // Qt includes
 #include <QGridLayout>
@@ -290,7 +291,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
       gridLay->addWidget(m_lyFld, 1, 4);
 
       gridLay->addWidget(m_arPrev, 2, 2, Qt::AlignRight | Qt::AlignVCenter);
-      //gridLay->addWidget(new QLabel(tr("A/R")), 2, 3, Qt::AlignCenter);
+      // gridLay->addWidget(new QLabel(tr("A/R")), 2, 3, Qt::AlignCenter);
       gridLay->addWidget(m_arFld, 2, 4);
       m_arFld->hide();
       m_arPrev->hide();
@@ -408,7 +409,11 @@ void CameraSettingsWidget::loadPresetList() {
   if (m_presetListFile == "") return;
   m_presetListOm->clear();
   m_presetListOm->addItem(tr("<custom>"));
-
+  if (!TFileStatus(TFilePath(m_presetListFile)).doesExist()) {
+    TFilePath presetTemplate =
+        TEnv::getConfigDir() + TFilePath(m_presetListFile).withoutParentDir();
+    TSystem::copyFile(TFilePath(m_presetListFile), presetTemplate);
+  }
   QFile file(m_presetListFile);
   if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
     QTextStream in(&file);


### PR DESCRIPTION
This PR moves user configuration/preference files saved in various places under 1 directory.  Keeping everything centrally located will help with upgrading and potentially sharing in the future.

Files will be saved under `tahomastuff\profiles\users\xxx`, where `xxx` is the user's username logging into the machine.

Here are the following files that will be relocated:

What|Old location|New Location
----|------------|------------
Preferences, config files and default palettes|profiles\layouts\settings.xxx\\*|profiles\users\xxx\\*
Application Variables|profiles\env\xxx.env|profiles\users\xxx\env.ini
Room Layouts|profiles\layouts\personal\Default.xxx\\*|profiles\users\xxx\layouts\Default\\*
Browser Room's history|config\xxx_history.txt|profiles\users\xxx\file_history.txt
Brush presets|config\brush_*.txt|profiles\users\xxx\brush_*.txt
Camera output presets|config\outputpresets\*|profiles\users\xxx\outputpresets\*
Resolution presets|config\reslist.txt|profiles\users\xxx\reslist.txt
Cleanup resolution presets|config\cleanupreslist.txt|profiles\users\xxx\cleanupreslist.txt

It should be noted that presets currently saved in the `config` directory by 1 user are available to all users on the machine because the filename does not indicate which user it is for. With this change, they become personal settings and are no longer shared by default.

A future enhancement for shared machines or networked installations would be to create a `profiles\users\template` folder to be used when creating new users. It would contain initial configurations/layouts set up by an admin user.