### PR TITLE
Fix autocreation preferences turning on accidentally

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -2641,6 +2641,11 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
   }
 
   if (!toolHandle->getTool()->m_isFrameCreated) {
+    if (!isAutoCreateEnabled)
+      Preferences::instance()->setValue(EnableAutocreation, false, false);
+    if (!isCreationInHoldCellsEnabled)
+      Preferences::instance()->setValue(EnableCreationInHoldCells, false,
+                                        false);
     if (!multiple)
       DVGui::warning(QObject::tr(
           "Unable to replace the current drawing with a blank drawing"));
@@ -2784,6 +2789,11 @@ void TCellSelection::duplicateFrame(int row, int col, bool multiple) {
 
   bool frameCreated = toolHandle->getTool()->m_isFrameCreated;
   if (!frameCreated) {
+    if (!isAutoCreateEnabled)
+      Preferences::instance()->setValue(EnableAutocreation, false, false);
+    if (!isCreationInHoldCellsEnabled)
+      Preferences::instance()->setValue(EnableCreationInHoldCells, false,
+                                        false);
     if (!multiple)
       DVGui::warning(
           QObject::tr("Unable to replace the current or next drawing with a "


### PR DESCRIPTION
This PR fixes an issue reported on the Tahoma2D Discord.

**Issue**:  Sometimes when the `Enable Creation in Hold Cells` is OFF, something causes it to turn on.

You can duplicate it as follows:
1. Disable preferences `Enable Creation in Hold Cells` and `Enable Autocreation`
2. Attempt to create 1 blank frame over a frame with an image on it, or duplicate 1 frame where the adjacent cell has an image -> You should get a warning that it failed.
3. Try to draw further down the timeline/xsheet -> Cells are filled as if both options are turned ON.

This change is not shown in Preferences.

**Reason**: When creating blank frames or duplicating frames, T2D (can we make this acronym a thing for Tahoma2D? hehe) will temporarily turn on `Enable Autocreation` and `Enable Creation in Hold Cells`.  If it turned it on temporarily, it's supposed to turn it off, however that does not happen when it cannot affect a cell that already has a drawing it.

**Fix**: Corrected logic to disable what was temporarily enabled when it fails to replace an existing drawing with a blank/duplicate.
