### PR TITLE
Fix current brush preset tracking

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -205,7 +205,9 @@ void FullColorBrushTool::onActivate() {
         QString::fromStdString(FullcolorBrushPreset.getValue()).toStdWString();
     if (wpreset != CUSTOM_WSTR) {
       initPresets();
+      if (!m_preset.isValue(wpreset)) wpreset = CUSTOM_WSTR;
       m_preset.setValue(wpreset);
+      FullcolorBrushPreset = m_preset.getValueAsString();
       loadPreset();
     } else
       loadLastBrush();
@@ -993,6 +995,7 @@ void FullColorBrushTool::addPreset(QString name) {
 
   // Set the value to the specified one
   m_preset.setValue(preset.m_name);
+  FullcolorBrushPreset = m_preset.getValueAsString();
 }
 
 //------------------------------------------------------------------
@@ -1006,6 +1009,7 @@ void FullColorBrushTool::removePreset() {
 
   // No parameter change, and set the preset value to custom
   m_preset.setValue(CUSTOM_WSTR);
+  FullcolorBrushPreset = m_preset.getValueAsString();
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1150,7 +1150,9 @@ void ToonzRasterBrushTool::onActivate() {
         QString::fromStdString(RasterBrushPreset.getValue()).toStdWString();
     if (wpreset != CUSTOM_WSTR) {
       initPresets();
+      if (!m_preset.isValue(wpreset)) wpreset = CUSTOM_WSTR;
       m_preset.setValue(wpreset);
+      RasterBrushPreset = m_preset.getValueAsString();
       loadPreset();
     } else
       loadLastBrush();
@@ -2460,6 +2462,7 @@ void ToonzRasterBrushTool::addPreset(QString name) {
 
   // Set the value to the specified one
   m_preset.setValue(preset.m_name);
+  RasterBrushPreset = m_preset.getValueAsString();
 }
 
 //------------------------------------------------------------------
@@ -2473,6 +2476,7 @@ void ToonzRasterBrushTool::removePreset() {
 
   // No parameter change, and set the preset value to custom
   m_preset.setValue(CUSTOM_WSTR);
+  RasterBrushPreset = m_preset.getValueAsString();
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -652,7 +652,9 @@ void ToonzVectorBrushTool::onActivate() {
         QString::fromStdString(V_VectorBrushPreset.getValue()).toStdWString();
     if (wpreset != CUSTOM_WSTR) {
       initPresets();
+      if (!m_preset.isValue(wpreset)) wpreset = CUSTOM_WSTR;
       m_preset.setValue(wpreset);
+      V_VectorBrushPreset = m_preset.getValueAsString();
       loadPreset();
     } else
       loadLastBrush();
@@ -2131,6 +2133,7 @@ void ToonzVectorBrushTool::addPreset(QString name) {
 
   // Set the value to the specified one
   m_preset.setValue(preset.m_name);
+  V_VectorBrushPreset = m_preset.getValueAsString();
 }
 
 //------------------------------------------------------------------
@@ -2144,6 +2147,7 @@ void ToonzVectorBrushTool::removePreset() {
 
   // No parameter change, and set the preset value to custom
   m_preset.setValue(CUSTOM_WSTR);
+  V_VectorBrushPreset = m_preset.getValueAsString();
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes 2 issues related to creating and deleting brush presets. 

**Issues**
1.  Creating brush preset names does not flag it as the current brush when saving

To Reproduce:
- Select Brush Tool
- Add Preset and name it BrushA
- Close and Reopen Tahoma2D
- Select Brush Tool -> Preset should be BrushA, but restores back to <Custom>

2. Deleting the current preset and then using the brush tool after restart causes crash

To Reproduce:
- Select Preset brush BrushA from above
- Delete preset BrushA
- Close and Reopen Tahoma2D
- Select Brush Tool -> Crash

Helped a user some time ago with # 2, but didn't know how that happened until recently.

**Fixes**
1. Added logic to update the environment variable to an appropriate value immediately after adding or deleting a preset.
2. Added logic to check if the value exists in the preset list and default it to "<custom>" if not found.