### PR TITLE
Fix create blank frame not using user default palette

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -349,6 +349,15 @@ TImage *TTool::touchImage() {
   TXshSimpleLevel *sl = cell.getSimpleLevel();
 
   if (sl) {
+    // If for some reason there is no palette, try and set a default one now.
+    if (!sl->getPalette() &&
+        (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL)) {
+      TPalette *defaultPalette =
+          getApplication()->getPaletteController()->getDefaultPalette(
+              sl->getType());
+      if (defaultPalette) sl->setPalette(defaultPalette->clone());
+    }
+
     // current cell is not empty
     if (isCreateInHoldCellsEnabled && row > 0 &&
         xsh->getCell(row - 1, col) == xsh->getCell(row, col)) {
@@ -443,6 +452,15 @@ TImage *TTool::touchImage() {
       // note: sl should be always !=0 (the column is not empty)
       // if - for some reason - it is == 0 or it is not editable,
       // then we skip to empty-column behaviour
+
+      // If for some reason there is no palette, try and set a default one now.
+      if (!sl->getPalette() &&
+          (sl->getType() == TZP_XSHLEVEL || sl->getType() == PLI_XSHLEVEL)) {
+        TPalette *defaultPalette =
+            getApplication()->getPaletteController()->getDefaultPalette(
+                sl->getType());
+        if (defaultPalette) sl->setPalette(defaultPalette->clone());
+      }
 
       // create the drawing
       // find the proper frameid

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -2028,7 +2028,7 @@ TImageP TXshSimpleLevel::createEmptyFrame() {
   // manner as createNewLevel() in order to avoid crash. This can be happened if
   // the level was not saved after creating and being placed in the xsheet.
   if (isEmpty()) {
-    initializePalette();
+    if (!getPalette()) initializePalette();
     initializeResolutionAndDpi();
   }
 


### PR DESCRIPTION
This PR fixes #404 

Added a check to only initialize the level with a base palette (clear, black) during new frame creation is there isn't one at the time of frame creation.

Added logic to try and set the user default palette on a level if it is missing a palette when creating a new frame via touchImage().  This is more of an enhancement of the OT crash fix so it uses the user default palette instead of the base palette.