### PR TITLE
Change project on choosing project from Startup Popup

### DIFF
--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -578,6 +578,30 @@ void StartupPopup::onProjectLocationChanged() {
       popup->setPath(path.getQString());
       popup->exec();
     }
+  } else {
+    if (!IoCmd::saveSceneIfNeeded(QObject::tr("Change Project"))) {
+      m_projectLocationFld->blockSignals(true);
+      m_projectLocationFld->setPath(TApp::instance()
+                                        ->getCurrentScene()
+                                        ->getScene()
+                                        ->getProject()
+                                        ->getProjectFolder()
+                                        .getQString());
+      m_projectLocationFld->blockSignals(false);
+      return;
+    }
+    TProjectManager *pm   = TProjectManager::instance();
+    TFilePath projectPath = pm->projectFolderToProjectPath(path);
+    pm->setCurrentProjectPath(projectPath);
+    TProject *projectP =
+        TProjectManager::instance()->getCurrentProject().getPointer();
+
+    // In case the project file was upgraded to current version, save it now
+    if (projectP->getProjectPath() != projectPath) {
+      projectP->save();
+    }
+
+    IoCmd::newScene();
   }
 }
 


### PR DESCRIPTION
fixes #403 
When the path to the project is changed, it changes the project immediately, asking to save the scene if needed.

The makes "Open Another Scene" start browsing from the same location as listed in the project file field.