### PR TITLE
Move opacity slider and change default ray opacity

### DIFF
--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -762,10 +762,10 @@ TPanelTitleBarButtonForGrids::TPanelTitleBarButtonForGrids(
 
   gridLayout->addWidget(horizonCheckbox, 5, 0, 1, 2);
   gridLayout->addWidget(isometricCheckbox, 6, 0, 1, 2);
-  gridLayout->addWidget(vanishingCheckbox, 7, 0, 1, 2);
   
-  gridLayout->addWidget(guideOpacityLabel, 8, 0);
-  gridLayout->addWidget(guideOpacitySlider, 8, 1);
+  gridLayout->addWidget(guideOpacityLabel, 7, 0);
+  gridLayout->addWidget(guideOpacitySlider, 7, 1);
+  gridLayout->addWidget(vanishingCheckbox, 8, 0, 1, 2);
   gridWidget->setLayout(gridLayout);
   gridsAction->setDefaultWidget(gridWidget);
   m_menu->addAction(gridsAction);

--- a/toonz/sources/toonz/viewerdraw.cpp
+++ b/toonz/sources/toonz/viewerdraw.cpp
@@ -58,7 +58,7 @@ TEnv::IntVar HorizonStep("HorizonStep", 5);
 TEnv::IntVar HorizonOffset("HorizonOffset", 0);
 TEnv::IntVar ShowVanishingPointRays("ShowVanishingPointRays", 1);
 TEnv::IntVar VanishingPointRayAngles("VanishingPointRayAngles", 10);
-TEnv::IntVar VanishingPointRayOpacity("VanishingPointRayOpacity", 80);
+TEnv::IntVar VanishingPointRayOpacity("VanishingPointRayOpacity", 35);
 
 /* TODO, move to include */
 void getSafeAreaSizeList(QList<QList<double>> &_sizeList);


### PR DESCRIPTION
This moves the grid opacity slider above the vanishing point stuff and changes the default ray opacity.  It was a bit harsh before.