### PR TITLE
Add Import Preferences option

### DIFF
--- a/toonz/sources/common/tapptools/tenv.cpp
+++ b/toonz/sources/common/tapptools/tenv.cpp
@@ -633,6 +633,7 @@ void TEnv::setStuffDir(const TFilePath &stuffDir) {
 }
 
 void TEnv::saveAllEnvVariables() { VariableSet::instance()->save(); }
+void TEnv::loadAllEnvVariables() { VariableSet::instance()->load(); }
 
 bool TEnv::setArgPathValue(std::string key, std::string value) {
   EnvGlobals *eg = EnvGlobals::instance();

--- a/toonz/sources/common/tsystem/tsystem.cpp
+++ b/toonz/sources/common/tsystem/tsystem.cpp
@@ -283,7 +283,8 @@ void TSystem::rmDirTree(const TFilePath &path) { ::rmDirTree(toQString(path)); }
 
 //------------------------------------------------------------
 
-void TSystem::copyDir(const TFilePath &dst, const TFilePath &src) {
+void TSystem::copyDir(const TFilePath &dst, const TFilePath &src,
+                      bool overwrite) {
   QFileInfoList fil = QDir(toQString(src)).entryInfoList();
 
   QDir::current().mkdir(toQString(dst));
@@ -296,9 +297,11 @@ void TSystem::copyDir(const TFilePath &dst, const TFilePath &src) {
     if (fi.isDir()) {
       TFilePath srcDir = TFilePath(fi.filePath().toStdString());
       TFilePath dstDir = dst + srcDir.getName();
-      copyDir(dstDir, srcDir);
+      copyDir(dstDir, srcDir, overwrite);
     } else {
       TFilePath srcFi = dst + TFilePath(fi.fileName());
+      if (overwrite && QFile::exists(toQString(srcFi)))
+        QFile::remove(toQString(srcFi));
       QFile::copy(fi.filePath(), toQString(srcFi));
     }
   }

--- a/toonz/sources/include/tenv.h
+++ b/toonz/sources/include/tenv.h
@@ -143,6 +143,7 @@ DVAPI TFilePath getWorkingDirectory();
 DVAPI void setStuffDir(const TFilePath &stuffDir);
 
 DVAPI void saveAllEnvVariables();
+DVAPI void loadAllEnvVariables();
 
 // register command line argument paths.
 // returns true on success

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -124,6 +124,8 @@ public:
   // Saving
   void setRasterBackgroundColor();
 
+  void load();
+
 public:
   static Preferences *instance();
 

--- a/toonz/sources/include/tsystem.h
+++ b/toonz/sources/include/tsystem.h
@@ -153,7 +153,8 @@ DVAPI int getProcessId();
 DVAPI void mkDir(const TFilePath &path);
 DVAPI void rmDir(const TFilePath &path);
 DVAPI void rmDirTree(const TFilePath &path);
-DVAPI void copyDir(const TFilePath &dst, const TFilePath &src);
+DVAPI void copyDir(const TFilePath &dst, const TFilePath &src,
+                   bool overwrite = false);
 DVAPI bool touchParentDir(const TFilePath &fp);
 
 DVAPI void touchFile(const TFilePath &path);

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3859,6 +3859,16 @@ void RecentFiles::clearRecentFilesList(FileType fileType) {
 
 //-----------------------------------------------------------------------------
 
+void RecentFiles::clearAllRecentFilesList(bool saveNow) {
+  m_recentScenes.clear();
+  m_recentSceneProjects.clear();
+  m_recentLevels.clear();
+  m_recentFlipbookImages.clear();
+  if (saveNow) saveRecentFiles();
+}
+
+//-----------------------------------------------------------------------------
+
 void RecentFiles::loadRecentFiles() {
   TFilePath fp = ToonzFolder::getMyModuleDir() + TFilePath("RecentFiles.ini");
   QSettings settings(toQString(fp), QSettings::IniFormat);
@@ -3929,6 +3939,14 @@ void RecentFiles::saveRecentFiles() {
   settings.setValue(QString("Levels"), QVariant(m_recentLevels));
   settings.setValue(QString("FlipbookImages"),
                     QVariant(m_recentFlipbookImages));
+}
+
+//-----------------------------------------------------------------------------
+
+void RecentFiles::updateStuffPath(QString oldPath, QString newPath) {
+  m_recentScenes.replaceInStrings(oldPath, newPath);
+  m_recentLevels.replaceInStrings(oldPath, newPath);
+  m_recentFlipbookImages.replaceInStrings(oldPath, newPath);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -358,8 +358,11 @@ public:
   QString getFileProject(QString fileName) const;
   QString getFileProject(int index) const;
   void clearRecentFilesList(FileType fileType);
+  void clearAllRecentFilesList(bool saveNow = true);
   void loadRecentFiles();
   void saveRecentFiles();
+
+  void updateStuffPath(QString oldPath, QString newPath);
 
 protected:
   void refreshRecentFilesMenu(FileType fileType);

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -2224,8 +2224,20 @@ void PreferencesPopup::onImport() {
     if (!TFileStatus(srcDir).doesExist())
       DVGui::warning("Failed to process Sandbox.\nCould not find " +
                      srcDir.getQString());
-    else
+    else {
       TSystem::copyDir(destDir, srcDir, true);
+
+      // Recent history needs to be updated
+      if (m_importPrefsCB->isChecked() &&
+          TFileStatus(ToonzFolder::getMyModuleDir() + L"RecentFiles.ini")
+              .doesExist()) {
+        RecentFiles::instance()->clearAllRecentFilesList(false);
+        RecentFiles::instance()->loadRecentFiles();
+        RecentFiles::instance()->updateStuffPath(srcDir.getQString(),
+                                                 destDir.getQString());
+        RecentFiles::instance()->saveRecentFiles();
+      }
+    }
 
     // -- Projects
     destDir = TEnv::getStuffDir() + L"projects";
@@ -2233,8 +2245,20 @@ void PreferencesPopup::onImport() {
     if (!TFileStatus(srcDir).doesExist())
       DVGui::warning("Failed to process Projects.\nCould not find " +
                      srcDir.getQString());
-    else
+    else {
       TSystem::copyDir(destDir, srcDir, true);
+
+      // Recent history needs to be updated
+      if (m_importPrefsCB->isChecked() &&
+          TFileStatus(ToonzFolder::getMyModuleDir() + L"RecentFiles.ini")
+              .doesExist()) {
+        RecentFiles::instance()->clearAllRecentFilesList(false);
+        RecentFiles::instance()->loadRecentFiles();
+        RecentFiles::instance()->updateStuffPath(srcDir.getQString(),
+                                                 destDir.getQString());
+        RecentFiles::instance()->saveRecentFiles();
+      }
+    }
   }
   //-------------------
   // --- Fxs and Plugins

--- a/toonz/sources/toonz/preferencespopup.h
+++ b/toonz/sources/toonz/preferencespopup.h
@@ -26,6 +26,8 @@ class QLineEdit;
 class QPushButton;
 class QLabel;
 class QGroupBox;
+class QListWidget;
+class QStackedWidget;
 
 //==============================================================
 
@@ -73,6 +75,19 @@ private:
   QPushButton* m_editLevelFormat;
   QComboBox* m_levelFormatNames;
 
+  QListWidget* m_categoryList;
+  QStackedWidget* m_stackedWidget;
+
+  // For importing preferences from a different installation
+  DVGui::FileField* m_importPrefpath;
+  QCheckBox* m_importPrefsCB;
+  QCheckBox* m_importRoomsCB;
+  QCheckBox* m_importProjectsCB;
+  QCheckBox* m_importFxPluginsCB;
+  QCheckBox* m_importStudioPalettesCB;
+  QCheckBox* m_importLibraryCB;
+  QCheckBox* m_importToonzfarmCB;
+
 private:
   void rebuildFormatsList();
   QList<ComboBoxItem> buildFontStyleList() const;
@@ -108,6 +123,7 @@ private:
   QWidget* createColorsPage();
   QWidget* createVersionControlPage();
   QWidget* createTouchTabletPage();
+  QWidget* createImportPrefsPage();
 
   //--- callbacks ---
   // General
@@ -160,6 +176,8 @@ private slots:
   void onEditLevelFormat();
   void onLevelFormatEdited();
   void onImportPolicyExternallyChanged(int policy);
+  void onImportPreferences();
+  void onImport();
 };
 
 //**********************************************************************************

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -208,7 +208,9 @@ bool Preferences::LevelFormat::matches(const TFilePath &fp) const {
 //    Preferences  implementation
 //**********************************************************************************
 
-Preferences::Preferences() {
+Preferences::Preferences() { load(); }
+
+void Preferences::load() {
   // load preference file
   TFilePath layoutDir = ToonzFolder::getMyModuleDir();
   TFilePath prefPath  = layoutDir + TFilePath("preferences.ini");


### PR DESCRIPTION
This PR adds an option to load Preferences and Settings from another installation of Tahoma2D.  This will aid in upgrading to newer versions of Tahoma2D without having to overwrite existing versions with the current.

![image](https://user-images.githubusercontent.com/19245851/97461117-d0051880-1913-11eb-8900-2b62aa89d051.png)

For Windows and Linux builds, users would need to select the folder containing the Tahoma2D application since the `tahomastuff` folder is also there.  Technically any folder containing a `tahomastuff` folder would work. 

For macOS, they have a slightly different message to select the Tahoma2D application itself, since the `tahomastuff` folder is buried inside it.

It is backwards compatible, in that it will pull files from old locations and store in the new location (`profiles\users\xxxx`)

For non-user specific files and directories (fx, studiopalette, plugins, library, sandbox, projects, toonzfarm), it performs a destructive merge.  Files found in source but not in destination are added, common files are replaced with source and files only in destination are not touched.

A restart is required, but not enforced, afterwards for room layouts and other preference changes to take effect.