### PR TITLE
Fix loading brush presets or last brush used

### DIFF
--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1891,7 +1891,6 @@ BrushToolOptionsBox::BrushToolOptionsBox(QWidget *parent, TTool *tool,
     builder.setSingleValueWidgetType(ToolOptionControlBuilder::FIELD);
 
     addSeparator();
-    if (tool && tool->getProperties(1)) tool->getProperties(1)->accept(builder);
     m_drawOrderCheckbox =
         dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Draw Under"));
     m_autoCloseCheckbox =
@@ -1904,6 +1903,8 @@ BrushToolOptionsBox::BrushToolOptionsBox(QWidget *parent, TTool *tool,
         dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Snap"));
     m_snapSensitivityCombo =
         dynamic_cast<ToolOptionCombo *>(m_controls.value("Sensitivity:"));
+
+    if (tool && tool->getProperties(1)) tool->getProperties(1)->accept(builder);
     m_joinStyleCombo =
         dynamic_cast<ToolOptionPopupButton *>(m_controls.value("Join"));
     m_miterField =

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2348,27 +2348,22 @@ bool ToonzRasterBrushTool::onPropertyChanged(std::string propertyName) {
     return true;
   }
 
-  /*--- Divide the process according to the changed Property ---*/
+  RasterBrushMinSize       = m_rasThickness.getValue().first;
+  RasterBrushMaxSize       = m_rasThickness.getValue().second;
+  BrushSmooth              = m_smooth.getValue();
+  BrushDrawOrder           = m_drawOrder.getIndex();
+  RasterBrushPencilMode    = m_pencil.getValue();
+  BrushPressureSensitivity = m_pressure.getValue();
+  RasterBrushHardness      = m_hardness.getValue();
+  RasterBrushModifierSize  = m_modifierSize.getValue();
 
-  /*--- determine which type of brush to be modified ---*/
+  // Recalculate/reset based on changed settings
   if (propertyName == m_rasThickness.getName()) {
-    RasterBrushMinSize = m_rasThickness.getValue().first;
-    RasterBrushMaxSize = m_rasThickness.getValue().second;
-
     m_minThick = m_rasThickness.getValue().first;
     m_maxThick = m_rasThickness.getValue().second;
-  } else if (propertyName == m_smooth.getName()) {
-    BrushSmooth = m_smooth.getValue();
-  } else if (propertyName == m_drawOrder.getName()) {
-    BrushDrawOrder = m_drawOrder.getIndex();
-  } else if (propertyName == m_pencil.getName()) {
-    RasterBrushPencilMode = m_pencil.getValue();
-  } else if (propertyName == m_pressure.getName()) {
-    BrushPressureSensitivity = m_pressure.getValue();
-  } else if (propertyName == m_hardness.getName())
-    setWorkAndBackupImages();
-  else if (propertyName == m_modifierSize.getName())
-    RasterBrushModifierSize = m_modifierSize.getValue();
+  }
+
+  if (propertyName == m_hardness.getName()) setWorkAndBackupImages();
 
   if (propertyName == m_hardness.getName() ||
       propertyName == m_rasThickness.getName()) {
@@ -2426,23 +2421,20 @@ void ToonzRasterBrushTool::loadPreset() {
   {
     m_rasThickness.setValue(
         TDoublePairProperty::Value(std::max(preset.m_min, 1.0), preset.m_max));
-    m_minThick = m_rasThickness.getValue().first;
-    m_maxThick = m_rasThickness.getValue().second;
-    m_brushPad = ToolUtils::getBrushPad(preset.m_max, preset.m_hardness * 0.01);
-    m_smooth.setValue(preset.m_smooth, true);
     m_hardness.setValue(preset.m_hardness, true);
+    m_smooth.setValue(preset.m_smooth, true);
     m_drawOrder.setIndex(preset.m_drawOrder);
     m_pencil.setValue(preset.m_pencil);
     m_pressure.setValue(preset.m_pressure);
     m_modifierSize.setValue(preset.m_modifierSize);
 
+    // Recalculate based on updated presets
+    m_minThick = m_rasThickness.getValue().first;
+    m_maxThick = m_rasThickness.getValue().second;
+
     setWorkAndBackupImages();
 
-    m_brushPad = getBrushPad(m_rasThickness.getValue().second,
-                             m_hardness.getValue() * 0.01);
-    TRectD rect(m_mousePos - TPointD(m_maxThick + 2, m_maxThick + 2),
-                m_mousePos + TPointD(m_maxThick + 2, m_maxThick + 2));
-    invalidate(rect);
+    m_brushPad = ToolUtils::getBrushPad(preset.m_max, preset.m_hardness * 0.01);
   } catch (...) {
   }
 }
@@ -2493,24 +2485,21 @@ void ToonzRasterBrushTool::removePreset() {
 void ToonzRasterBrushTool::loadLastBrush() {
   m_rasThickness.setValue(
       TDoublePairProperty::Value(RasterBrushMinSize, RasterBrushMaxSize));
-  m_minThick = m_rasThickness.getValue().first;
-  m_maxThick = m_rasThickness.getValue().second;
-
   m_drawOrder.setIndex(BrushDrawOrder);
   m_pencil.setValue(RasterBrushPencilMode ? 1 : 0);
   m_hardness.setValue(RasterBrushHardness);
-
   m_pressure.setValue(BrushPressureSensitivity ? 1 : 0);
   m_smooth.setValue(BrushSmooth);
   m_modifierSize.setValue(RasterBrushModifierSize);
+
+  // Recalculate based on prior values
+  m_minThick = m_rasThickness.getValue().first;
+  m_maxThick = m_rasThickness.getValue().second;
 
   setWorkAndBackupImages();
 
   m_brushPad = getBrushPad(m_rasThickness.getValue().second,
                            m_hardness.getValue() * 0.01);
-  TRectD rect(m_mousePos - TPointD(m_maxThick + 2, m_maxThick + 2),
-              m_mousePos + TPointD(m_maxThick + 2, m_maxThick + 2));
-  invalidate(rect);
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -2426,6 +2426,8 @@ void ToonzRasterBrushTool::loadPreset() {
   {
     m_rasThickness.setValue(
         TDoublePairProperty::Value(std::max(preset.m_min, 1.0), preset.m_max));
+    m_minThick = m_rasThickness.getValue().first;
+    m_maxThick = m_rasThickness.getValue().second;
     m_brushPad = ToolUtils::getBrushPad(preset.m_max, preset.m_hardness * 0.01);
     m_smooth.setValue(preset.m_smooth, true);
     m_hardness.setValue(preset.m_hardness, true);
@@ -2434,6 +2436,13 @@ void ToonzRasterBrushTool::loadPreset() {
     m_pressure.setValue(preset.m_pressure);
     m_modifierSize.setValue(preset.m_modifierSize);
 
+    setWorkAndBackupImages();
+
+    m_brushPad = getBrushPad(m_rasThickness.getValue().second,
+                             m_hardness.getValue() * 0.01);
+    TRectD rect(m_mousePos - TPointD(m_maxThick + 2, m_maxThick + 2),
+                m_mousePos + TPointD(m_maxThick + 2, m_maxThick + 2));
+    invalidate(rect);
   } catch (...) {
   }
 }
@@ -2484,6 +2493,8 @@ void ToonzRasterBrushTool::removePreset() {
 void ToonzRasterBrushTool::loadLastBrush() {
   m_rasThickness.setValue(
       TDoublePairProperty::Value(RasterBrushMinSize, RasterBrushMaxSize));
+  m_minThick = m_rasThickness.getValue().first;
+  m_maxThick = m_rasThickness.getValue().second;
 
   m_drawOrder.setIndex(BrushDrawOrder);
   m_pencil.setValue(RasterBrushPencilMode ? 1 : 0);
@@ -2492,6 +2503,14 @@ void ToonzRasterBrushTool::loadLastBrush() {
   m_pressure.setValue(BrushPressureSensitivity ? 1 : 0);
   m_smooth.setValue(BrushSmooth);
   m_modifierSize.setValue(RasterBrushModifierSize);
+
+  setWorkAndBackupImages();
+
+  m_brushPad = getBrushPad(m_rasThickness.getValue().second,
+                           m_hardness.getValue() * 0.01);
+  TRectD rect(m_mousePos - TPointD(m_maxThick + 2, m_maxThick + 2),
+              m_mousePos + TPointD(m_maxThick + 2, m_maxThick + 2));
+  invalidate(rect);
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1941,110 +1941,90 @@ bool ToonzVectorBrushTool::onPropertyChanged(std::string propertyName) {
     return true;
   }
 
-  /*--- Divide the process according to the changed Property ---*/
+  // Properties tracked with preset
+  V_VectorBrushMinSize       = m_thickness.getValue().first;
+  V_VectorBrushMaxSize       = m_thickness.getValue().second;
+  V_BrushAccuracy            = m_accuracy.getValue();
+  V_BrushSmooth              = m_smooth.getValue();
+  V_BrushBreakSharpAngles    = m_breakAngles.getValue();
+  V_BrushPressureSensitivity = m_pressure.getValue();
+  V_VectorCapStyle           = m_capStyle.getIndex();
+  V_VectorJoinStyle          = m_joinStyle.getIndex();
+  V_VectorMiterValue         = m_miterJoinLimit.getValue();
 
-  /*--- determine which type of brush to be modified ---*/
-  if (propertyName == m_thickness.getName()) {
-    V_VectorBrushMinSize = m_thickness.getValue().first;
-    V_VectorBrushMaxSize = m_thickness.getValue().second;
-    m_minThick           = m_thickness.getValue().first;
-    m_maxThick           = m_thickness.getValue().second;
-  } else if (propertyName == m_accuracy.getName()) {
-    V_BrushAccuracy = m_accuracy.getValue();
-  } else if (propertyName == m_smooth.getName()) {
-    V_BrushSmooth = m_smooth.getValue();
-  } else if (propertyName == m_breakAngles.getName()) {
-    V_BrushBreakSharpAngles = m_breakAngles.getValue();
-  } else if (propertyName == m_pressure.getName()) {
-    V_BrushPressureSensitivity = m_pressure.getValue();
-  } else if (propertyName == m_capStyle.getName()) {
-    V_VectorCapStyle = m_capStyle.getIndex();
-  } else if (propertyName == m_joinStyle.getName()) {
-    V_VectorJoinStyle = m_joinStyle.getIndex();
-  } else if (propertyName == m_miterJoinLimit.getName()) {
-    V_VectorMiterValue = m_miterJoinLimit.getValue();
-  } else if (propertyName == m_frameRange.getName()) {
-    int index               = m_frameRange.getIndex();
-    V_VectorBrushFrameRange = index;
-    if (index == 0) resetFrameRange();
-  } else if (propertyName == m_sendToBack.getName()) {
-    V_VectorBrushDrawBehind = m_sendToBack.getValue();
-  } else if (propertyName == m_autoClose.getName()) {
-    if (!m_autoClose.getValue()) {
-      m_autoFill.setValue(false);
-      m_autoGroup.setValue(false);
-      V_VectorBrushAutoFill  = 0;
-      V_VectorBrushAutoGroup = 0;
-      // this is ugly: it's needed to refresh the GUI of the toolbar after
-      // having set to false the autofill...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          "");  // necessary, otherwise next setTool is ignored...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          QString::fromStdString(getName()));
-    }
-    V_VectorBrushAutoClose = m_autoClose.getValue();
-  } else if (propertyName == m_autoGroup.getName()) {
+  // Properties not tracked with preset
+  int frameIndex               = m_frameRange.getIndex();
+  V_VectorBrushFrameRange      = frameIndex;
+  V_VectorBrushDrawBehind      = m_sendToBack.getValue();
+  V_VectorBrushAutoClose       = m_autoClose.getValue();
+  V_VectorBrushAutoGroup       = m_autoGroup.getValue();
+  V_VectorBrushAutoFill        = m_autoFill.getValue();
+  V_VectorBrushSnap            = m_snap.getValue();
+  int snapSensitivityIndex     = m_snapSensitivity.getIndex();
+  V_VectorBrushSnapSensitivity = snapSensitivityIndex;
+
+  // Recalculate/reset based on changed settings
+  m_minThick = m_thickness.getValue().first;
+  m_maxThick = m_thickness.getValue().second;
+
+  if (frameIndex == 0) resetFrameRange();
+
+  switch (snapSensitivityIndex) {
+  case 0:
+    m_minDistance2 = SNAPPING_LOW;
+    break;
+  case 1:
+    m_minDistance2 = SNAPPING_MEDIUM;
+    break;
+  case 2:
+    m_minDistance2 = SNAPPING_HIGH;
+    break;
+  }
+
+  if (propertyName == m_autoClose.getName() && !m_autoClose.getValue()) {
+    m_autoFill.setValue(false);
+    m_autoGroup.setValue(false);
+    V_VectorBrushAutoFill  = m_autoFill.getValue();
+    V_VectorBrushAutoGroup = m_autoGroup.getValue();
+    notifyTool             = true;
+  }
+
+  if (propertyName == m_autoGroup.getName()) {
     // We need close turned on if on,
     // We need autofill off if off.
     if (m_autoGroup.getValue()) {
       m_autoClose.setValue(true);
-      V_VectorBrushAutoClose = 1;
-      // this is ugly: it's needed to refresh the GUI of the toolbar after
-      // having set to false the autofill...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          "");  // necessary, otherwise next setTool is ignored...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          QString::fromStdString(getName()));
+      V_VectorBrushAutoClose = m_autoClose.getValue();
+      notifyTool             = true;
     }
     if (!m_autoGroup.getValue() && m_autoFill.getValue()) {
       m_autoFill.setValue(false);
-      V_VectorBrushAutoFill = 0;
-      // this is ugly: it's needed to refresh the GUI of the toolbar after
-      // having set to false the autofill...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          "");  // necessary, otherwise next setTool is ignored...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          QString::fromStdString(getName()));
+      V_VectorBrushAutoFill = m_autoFill.getValue();
+      notifyTool            = true;
     }
-    V_VectorBrushAutoGroup = m_autoGroup.getValue();
-  } else if (propertyName == m_autoFill.getName()) {
-    // we need close and group on
-    if (m_autoFill.getValue()) {
-      m_autoClose.setValue(true);
-      m_autoGroup.setValue(true);
-      V_VectorBrushAutoClose = 1;
-      V_VectorBrushAutoGroup = 1;
-      // this is ugly: it's needed to refresh the GUI of the toolbar after
-      // having set to false the autofill...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          "");  // necessary, otherwise next setTool is ignored...
-      TTool::getApplication()->getCurrentTool()->setTool(
-          QString::fromStdString(getName()));
-    }
-    V_VectorBrushAutoFill = m_autoFill.getValue();
   }
 
-  else if (propertyName == m_snap.getName()) {
-    V_VectorBrushSnap = m_snap.getValue();
-  } else if (propertyName == m_snapSensitivity.getName()) {
-    int index                    = m_snapSensitivity.getIndex();
-    V_VectorBrushSnapSensitivity = index;
-    switch (index) {
-    case 0:
-      m_minDistance2 = SNAPPING_LOW;
-      break;
-    case 1:
-      m_minDistance2 = SNAPPING_MEDIUM;
-      break;
-    case 2:
-      m_minDistance2 = SNAPPING_HIGH;
-      break;
-    }
+  // we need close and group on
+  if (propertyName == m_autoFill.getName() && m_autoFill.getValue()) {
+    m_autoClose.setValue(true);
+    m_autoGroup.setValue(true);
+    V_VectorBrushAutoClose = m_autoClose.getValue();
+    V_VectorBrushAutoGroup = m_autoGroup.getValue();
+    notifyTool             = true;
   }
 
   if (propertyName == m_joinStyle.getName()) notifyTool = true;
 
-  if (m_preset.getValue() != CUSTOM_WSTR) {
+  // Switch to <custom> only if it's a preset property change
+  if (m_preset.getValue() != CUSTOM_WSTR &&
+      (propertyName == m_thickness.getName() ||
+       propertyName == m_accuracy.getName() ||
+       propertyName == m_smooth.getName() ||
+       propertyName == m_breakAngles.getName() ||
+       propertyName == m_pressure.getName() ||
+       propertyName == m_capStyle.getName() ||
+       propertyName == m_joinStyle.getName() ||
+       propertyName == m_miterJoinLimit.getName())) {
     m_preset.setValue(CUSTOM_WSTR);
     V_VectorBrushPreset = m_preset.getValueAsString();
     notifyTool          = true;
@@ -2094,8 +2074,6 @@ void ToonzVectorBrushTool::loadPreset() {
   {
     m_thickness.setValue(
         TDoublePairProperty::Value(preset.m_min, preset.m_max));
-    m_minThick = m_thickness.getValue().first;
-    m_maxThick = m_thickness.getValue().second;
     m_accuracy.setValue(preset.m_acc, true);
     m_smooth.setValue(preset.m_smooth, true);
     m_breakAngles.setValue(preset.m_breakAngles);
@@ -2104,6 +2082,9 @@ void ToonzVectorBrushTool::loadPreset() {
     m_joinStyle.setIndex(preset.m_join);
     m_miterJoinLimit.setValue(preset.m_miter);
 
+    // Recalculate based on updated presets
+    m_minThick = m_thickness.getValue().first;
+    m_maxThick = m_thickness.getValue().second;
   } catch (...) {
   }
 }
@@ -2153,20 +2134,18 @@ void ToonzVectorBrushTool::removePreset() {
 //------------------------------------------------------------------
 
 void ToonzVectorBrushTool::loadLastBrush() {
+  // Properties tracked with preset
   m_thickness.setValue(
       TDoublePairProperty::Value(V_VectorBrushMinSize, V_VectorBrushMaxSize));
-  m_minThick = m_thickness.getValue().first;
-  m_maxThick = m_thickness.getValue().second;
-
   m_capStyle.setIndex(V_VectorCapStyle);
   m_joinStyle.setIndex(V_VectorJoinStyle);
   m_miterJoinLimit.setValue(V_VectorMiterValue);
   m_breakAngles.setValue(V_BrushBreakSharpAngles ? 1 : 0);
   m_accuracy.setValue(V_BrushAccuracy);
-
   m_pressure.setValue(V_BrushPressureSensitivity ? 1 : 0);
   m_smooth.setValue(V_BrushSmooth);
 
+  // Properties not tracked with preset
   m_frameRange.setIndex(V_VectorBrushFrameRange);
   m_snap.setValue(V_VectorBrushSnap);
   m_snapSensitivity.setIndex(V_VectorBrushSnapSensitivity);
@@ -2175,24 +2154,24 @@ void ToonzVectorBrushTool::loadLastBrush() {
   m_autoClose.setValue(V_VectorBrushAutoClose);
   m_autoFill.setValue(V_VectorBrushAutoFill);
 
-  bool updateTool = false;
+  // Recalculate based on prior values
+  m_minThick = m_thickness.getValue().first;
+  m_maxThick = m_thickness.getValue().second;
+
   if (m_autoFill.getValue()) {
     if (!m_autoClose.getValue()) {
       m_autoClose.setValue(true);
       V_VectorBrushAutoClose = 1;
-      updateTool             = true;
     }
     if (!m_autoGroup.getValue()) {
       m_autoGroup.setValue(true);
       V_VectorBrushAutoGroup = 1;
-      updateTool             = true;
     }
   }
 
   if (m_autoGroup.getValue() && !m_autoClose.getValue()) {
     m_autoClose.setValue(true);
     V_VectorBrushAutoClose = 1;
-    updateTool             = true;
   }
 
   switch (V_VectorBrushSnapSensitivity) {
@@ -2205,15 +2184,6 @@ void ToonzVectorBrushTool::loadLastBrush() {
   case 2:
     m_minDistance2 = SNAPPING_HIGH;
     break;
-  }
-
-  if (updateTool) {
-    // this is ugly: it's needed to refresh the GUI of the toolbar after
-    // having set to false the autofill...
-    TTool::getApplication()->getCurrentTool()->setTool(
-        "");  // necessary, otherwise next setTool is ignored...
-    TTool::getApplication()->getCurrentTool()->setTool(
-        QString::fromStdString(getName()));
   }
 }
 

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1941,16 +1941,33 @@ bool ToonzVectorBrushTool::onPropertyChanged(std::string propertyName) {
     return true;
   }
 
-  // Properties tracked with preset
-  V_VectorBrushMinSize       = m_thickness.getValue().first;
-  V_VectorBrushMaxSize       = m_thickness.getValue().second;
-  V_BrushAccuracy            = m_accuracy.getValue();
-  V_BrushSmooth              = m_smooth.getValue();
-  V_BrushBreakSharpAngles    = m_breakAngles.getValue();
-  V_BrushPressureSensitivity = m_pressure.getValue();
-  V_VectorCapStyle           = m_capStyle.getIndex();
-  V_VectorJoinStyle          = m_joinStyle.getIndex();
-  V_VectorMiterValue         = m_miterJoinLimit.getValue();
+  // Switch to <custom> only if it's a preset property change
+  if (m_preset.getValue() != CUSTOM_WSTR &&
+      (propertyName == m_thickness.getName() ||
+       propertyName == m_accuracy.getName() ||
+       propertyName == m_smooth.getName() ||
+       propertyName == m_breakAngles.getName() ||
+       propertyName == m_pressure.getName() ||
+       propertyName == m_capStyle.getName() ||
+       propertyName == m_joinStyle.getName() ||
+       propertyName == m_miterJoinLimit.getName())) {
+    m_preset.setValue(CUSTOM_WSTR);
+    V_VectorBrushPreset = m_preset.getValueAsString();
+    notifyTool          = true;
+  }
+
+  // Properties tracked with preset. Update only on <custom>
+  if (m_preset.getValue() == CUSTOM_WSTR) {
+    V_VectorBrushMinSize       = m_thickness.getValue().first;
+    V_VectorBrushMaxSize       = m_thickness.getValue().second;
+    V_BrushAccuracy            = m_accuracy.getValue();
+    V_BrushSmooth              = m_smooth.getValue();
+    V_BrushBreakSharpAngles    = m_breakAngles.getValue();
+    V_BrushPressureSensitivity = m_pressure.getValue();
+    V_VectorCapStyle           = m_capStyle.getIndex();
+    V_VectorJoinStyle          = m_joinStyle.getIndex();
+    V_VectorMiterValue         = m_miterJoinLimit.getValue();
+  }
 
   // Properties not tracked with preset
   int frameIndex               = m_frameRange.getIndex();
@@ -2014,21 +2031,6 @@ bool ToonzVectorBrushTool::onPropertyChanged(std::string propertyName) {
   }
 
   if (propertyName == m_joinStyle.getName()) notifyTool = true;
-
-  // Switch to <custom> only if it's a preset property change
-  if (m_preset.getValue() != CUSTOM_WSTR &&
-      (propertyName == m_thickness.getName() ||
-       propertyName == m_accuracy.getName() ||
-       propertyName == m_smooth.getName() ||
-       propertyName == m_breakAngles.getName() ||
-       propertyName == m_pressure.getName() ||
-       propertyName == m_capStyle.getName() ||
-       propertyName == m_joinStyle.getName() ||
-       propertyName == m_miterJoinLimit.getName())) {
-    m_preset.setValue(CUSTOM_WSTR);
-    V_VectorBrushPreset = m_preset.getValueAsString();
-    notifyTool          = true;
-  }
 
   if (notifyTool) {
     m_propertyUpdating = true;


### PR DESCRIPTION
This PR does the following

1.  Fixes a crash when loading a custom preset Smart Raster brush with a `Hardness` setting < 100. 

Issue: Some internal variables to handle Smart Raster brush with `Hardness` < 100 were not initialized correctly when loading a preset and crashed when used.

Resolution: Ensured when loading a preset, the appropriate logic was followed as if the `Hardness` value was changed so that internal variables were initialized accordingly.

2. Logic for loading preset brushes or reloading the last brush used enhanced

Issue: When certain brush options are changed on the tool's option bar, it can trigger additional logic which can impact how the brush works.  When restoring presets or restoring the last brush used, this logic was not being performed and could impact the behavior of the brush. I reviewed all 3 brush types and found potential issues with Vector and Smart Raster brushes.

Resolution:  Updated the `loadPreset()` and `loadLastBrush()` logic to include any additional logic that would normally be triggered when changing brush properties on the tool's option bar.

3. No longer set you back to `<custom>` preset when modifying an option not saved with preset.

Issue: Was forcing back to custom on any property change, which it didn't need to be.

Resolution: Added condition only when a preset value changes.

4. `notifyTool` was not properly updating some of the Vector checkboxes

Issue: The checkboxes were part of Property set 0, but when setting up the controls, it was binding them under Property Set 1

Resolution: Moved the binding of controls to properties in the section that handles Property set 0.