### PR TITLE
Fix default permissions on tahomastuff

### DIFF
--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -15,6 +15,7 @@ then
    rm -rf $TOONZDIR/Tahoma2D.app/tahomastuff
 fi
 cp -R stuff $TOONZDIR/Tahoma2D.app/tahomastuff
+chmod -R 777 $TOONZDIR/Tahoma2D.app/tahomastuff
 
 if [ -d thirdparty/ffmpeg/bin ]
 then


### PR DESCRIPTION
This PR fixes #463 

For macOS,  it forces full permissions on the initial `tahomastuff` folder when building the package to ensure proper access to all users of Tahoma on the machine. (already does that for Linux users)

Also added an empty `profiles\users` directory which will also get full permissions so Tahoma can create profiles for different users, despite whomever installed Tahoma to begin with.

