### PR TITLE
Fix crash moving cell with shaderfx

### DIFF
--- a/toonz/sources/toonzqt/stageobjectsdata.cpp
+++ b/toonz/sources/toonzqt/stageobjectsdata.cpp
@@ -75,7 +75,8 @@ FxCanGenerateState canGenerate(const std::set<TFx *> &fxsSet, TFx *fx) {
 
 //! Returns whether the specified fx is a downstream node of the xsheet node.
 bool hasTerminalUpstream(TFx *fx, TFxSet *terminalFxs) {
-  if (TZeraryFx *zfx = dynamic_cast<TZeraryFx *>(fx))
+  TZeraryFx *zfx = dynamic_cast<TZeraryFx *>(fx);
+  if (zfx && zfx->getColumnFx())
     return hasTerminalUpstream(zfx->getColumnFx(), terminalFxs);
 
   if (terminalFxs->containsFx(fx)) return true;


### PR DESCRIPTION
This PR fixes #488 

Issue: ShaderFx are derived from ZeraryFx, which normally creates a column with no input when used in an animation.

In the case of `GPU Radial Blur` and `GPU Spin Blur`, they don't generate a column.  When moving a level with an attached shader in the timeline, it was was hitting logic that expected the shader to have a column and would lead to a crash when it didn't.

Modified the logic to check for a column and act accordingly.