### PR TITLE
Fix motion path issues

### DIFF
--- a/toonz/sources/tnztools/geometrictool.cpp
+++ b/toonz/sources/tnztools/geometrictool.cpp
@@ -1285,14 +1285,16 @@ public:
       bool isSpline        = false;
       if (TTool::getApplication()->getCurrentObject()->isSpline()) {
         isSpline = true;
-        if (!ToolUtils::isJustCreatedSpline(vi.getPointer())) {
-          m_primitive->setIsPrompting(true);
-          QString question("Are you sure you want to replace the motion path?");
-          int ret =
-              DVGui::MsgBox(question, QObject::tr("Yes"), QObject::tr("No"), 0);
-          m_primitive->setIsPrompting(false);
-          if (ret == 2 || ret == 0) return;
-        }
+        // if (!ToolUtils::isJustCreatedSpline(vi.getPointer())) {
+        //  m_primitive->setIsPrompting(true);
+        //  QString question("Are you sure you want to replace the motion
+        //  path?");
+        //  int ret =
+        //      DVGui::MsgBox(question, QObject::tr("Yes"), QObject::tr("No"),
+        //      0);
+        //  m_primitive->setIsPrompting(false);
+        //  if (ret == 2 || ret == 0) return;
+        //}
         QMutexLocker lock(vi->getMutex());
         TUndo *undo = new UndoPath(
             getXsheet()->getStageObject(getObjectId())->getSpline());

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1091,17 +1091,17 @@ void ToonzVectorBrushTool::leftButtonUp(const TPointD &pos,
       ~Cleanup() { m_this->m_track.clear(), m_this->invalidate(); }
     } cleanup = {this};
 
-    if (!isJustCreatedSpline(vi.getPointer())) {
-      m_isPrompting = true;
+    // if (!isJustCreatedSpline(vi.getPointer())) {
+    //  m_isPrompting = true;
 
-      QString question("Are you sure you want to replace the motion path?");
-      int ret =
-          DVGui::MsgBox(question, QObject::tr("Yes"), QObject::tr("No"), 0);
+    //  QString question("Are you sure you want to replace the motion path?");
+    //  int ret =
+    //      DVGui::MsgBox(question, QObject::tr("Yes"), QObject::tr("No"), 0);
 
-      m_isPrompting = false;
+    //  m_isPrompting = false;
 
-      if (ret == 2 || ret == 0) return;
-    }
+    //  if (ret == 2 || ret == 0) return;
+    //}
 
     QMutexLocker lock(vi->getMutex());
 

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -12,9 +12,10 @@
 #include "toonz/tcolumnhandle.h"
 #include "toonz/txshlevel.h"
 #include "toonz/txshleveltypes.h"
-
+#include "toonz/tobjecthandle.h"
 #include "toonzqt/tselectionhandle.h"
 #include "toonzqt/selection.h"
+#include "toonz/tstageobjecttree.h"
 
 #include "tools/tool.h"
 
@@ -37,6 +38,7 @@ StatusBar::StatusBar(QWidget* parent) : QStatusBar(parent) {
   TApp* app                    = TApp::instance();
   TFrameHandle* frameHandle    = app->getCurrentFrame();
   TXshLevelHandle* levelHandle = app->getCurrentLevel();
+  TObjectHandle* object        = app->getCurrentObject();
 
   bool ret = true;
 
@@ -46,6 +48,8 @@ StatusBar::StatusBar(QWidget* parent) : QStatusBar(parent) {
                        SLOT(updateInfoText()));
   ret = ret && connect(levelHandle, SIGNAL(xshLevelChanged()), this,
                        SLOT(updateInfoText()));
+  ret = ret &&
+        connect(object, SIGNAL(objectSwitched()), this, SLOT(updateInfoText()));
 
   assert(ret);
 
@@ -73,7 +77,16 @@ void StatusBar::updateInfoText() {
   TApp* app              = TApp::instance();
   ToolHandle* toolHandle = app->getCurrentTool();
   TTool* tool            = toolHandle->getTool();
-  std::string name       = tool->getName();
+  TObjectHandle* object  = app->getCurrentObject();
+  TStageObjectTree* tree =
+      app->getCurrentXsheet()->getXsheet()->getStageObjectTree();
+  if (object->isSpline()) {
+    m_infoLabel->setText(
+        tr("Motion Path Selected: Click on a level or frame to leave motion "
+           "path editing."));
+    return;
+  }
+  std::string name = tool->getName();
   tool->getToolType();
   int target = tool->getTargetType();
 
@@ -128,19 +141,20 @@ void StatusBar::makeMap() {
                     "Animate Tool: Modifies the position, rotation and size of "
                     "the current column"});
   m_infoMap.insert({"T_Brush", "Brush Tool: Draws in the work area freehand"});
-  m_infoMap.insert({"T_BrushVector",
-                    "Brush Tool: Draws in the work area freehand" + spacer +
-                        "Shift - Straight Lines" + spacer +
+  m_infoMap.insert(
+      {"T_BrushVector", "Brush Tool: Draws in the work area freehand" + spacer +
+                            "Shift - Straight Lines" + spacer +
 #ifdef MACOSX
-                        "Cmd - Straight Lines Snapped to Angles" + spacer +
-                        "Cmd + Opt - Add / Remove Vanishing Point" + spacer +
-                        "Opt - Draw to Vanishing Point" + spacer +
-                        "Hold Cmd + Shift - Toggle Snapping"});
+                            "Cmd - Straight Lines Snapped to Angles" + spacer +
+                            "Cmd + Opt - Add / Remove Vanishing Point" +
+                            spacer + "Opt - Draw to Vanishing Point" + spacer +
+                            "Hold Cmd + Shift - Toggle Snapping"});
 #else
-                        "Control - Straight Lines Snapped to Angles" + spacer +
-                        "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
-                        "Alt - Draw to Vanishing Point" + spacer +
-                        "Hold Ctrl + Shift - Toggle Snapping"});
+                            "Control - Straight Lines Snapped to Angles" +
+                            spacer +
+                            "Ctrl + Alt - Add / Remove Vanishing Point" +
+                            spacer + "Alt - Draw to Vanishing Point" + spacer +
+                            "Hold Ctrl + Shift - Toggle Snapping"});
 #endif
   m_infoMap.insert({"T_BrushSmartRaster",
                     "Brush Tool: Draws in the work area freehand" + spacer +
@@ -154,25 +168,26 @@ void StatusBar::makeMap() {
                         "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
                         "Alt - Draw to Vanishing Point"});
 #endif
-  m_infoMap.insert({"T_BrushRaster",
-                    "Brush Tool: Draws in the work area freehand" + spacer +
-                        "Shift - Straight Lines" + spacer +
+  m_infoMap.insert(
+      {"T_BrushRaster", "Brush Tool: Draws in the work area freehand" + spacer +
+                            "Shift - Straight Lines" + spacer +
 #ifdef MACOSX
-                        "Cmd - Straight Lines Snapped to Angles" + spacer +
-                        "Cmd + Opt - Add / Remove Vanishing Point" + spacer +
-                        "Opt - Draw to Vanishing Point"});
+                            "Cmd - Straight Lines Snapped to Angles" + spacer +
+                            "Cmd + Opt - Add / Remove Vanishing Point" +
+                            spacer + "Opt - Draw to Vanishing Point"});
 #else
-                        "Control - Straight Lines Snapped to Angles" + spacer +
-                        "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
-                        "Alt - Draw to Vanishing Point"});
+                            "Control - Straight Lines Snapped to Angles" +
+                            spacer +
+                            "Ctrl + Alt - Add / Remove Vanishing Point" +
+                            spacer + "Alt - Draw to Vanishing Point"});
 #endif
   m_infoMap.insert({"T_Geometric", "Geometry Tool: Draws geometric shapes"});
-  m_infoMap.insert({ "T_GeometricVector", "Geometry Tool: Draws geometric shapes" +
-                                       spacer +
+  m_infoMap.insert(
+      {"T_GeometricVector", "Geometry Tool: Draws geometric shapes" + spacer +
 #ifdef MACOSX
-                        "Hold Cmd + Shift - Toggle Snapping" });
+                                "Hold Cmd + Shift - Toggle Snapping"});
 #else
-                                       "Hold Ctrl + Shift - Toggle Snapping" });
+                                "Hold Ctrl + Shift - Toggle Snapping"});
 #endif
   m_infoMap.insert({"T_Type", "Type Tool: Adds text"});
   m_infoMap.insert(


### PR DESCRIPTION
This does a number of user experience things:
It removes the dialog asking the user to confirm that they want to replace the motion path.  Changing a motion path is undoable, so that dialog isn't really necessary.

This dialog was causing an issue with using pens.  Clicking an option of the dialog was registering as a pen press in the viewer.  I'm curious if there are other instances where this is an issue.

It adds text to the viewer when a motion path is selected that says "Motion Path Selected" in the top corner.  This is to help clarify the situation when the brush or geometry tool is used while a motion path is selected,

It adds a status bar message indicating when a motion path is selected and how to get out of motion path editing.

It fixes some motion path visibility issues.