### PR TITLE
Fix guidedstroke in sceneviewer

### DIFF
--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -2130,8 +2130,8 @@ void SceneViewer::drawScene() {
       args.m_osm         = &osm;
       args.m_xsheetLevel = xsheetLevel;
       args.m_isPlaying   = frameHandle->isPlaying();
-      if (app->getCurrentColumn()->getColumn() &&
-          !app->getCurrentColumn()->getColumn()->getSoundColumn())
+      if (app->getCurrentLevel() && app->getCurrentLevel()->getLevel() &&
+          !app->getCurrentLevel()->getLevel()->getSoundLevel())
         args.m_currentFrameId =
             app->getCurrentXsheet()
                 ->getXsheet()


### PR DESCRIPTION
This PR fixes #502 

Issue: A change made for #402 prevented the population of the current frame variable for sound columns when drawing the frame in the sceneviewer. However, `app->getCurrentColumn()->getColumn()` may not return an actual column object even though the `getColumnIndex()` is populated properly. Since the current frame variable was not populated, guided controls didn't know what frame it was on.

Resolution: Switched to use `getCurrentLevel()->getLevel()` instead when determing if the current frame variable should be populated or not.