### PR TITLE
Fix resize handles not showing on hover

### DIFF
--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -491,14 +491,12 @@ void DockLayout::redistribute(bool allowFixedItems) {
     // Recompute Layout geometry
     m_regions.front()->setGeometry(contentsRect());
     m_regions.front()->redistribute();
-    if (allowFixedItems) {
-      if (widgetsCanBeFixedWidth) {
-        for (QWidget *widget : fixedWidthWidgets) {
-          widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-          widget->setMinimumSize(0, 0);
-        }
-      }
+
+    for (QWidget *widget : fixedWidthWidgets) {
+      widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+      widget->setMinimumSize(0, 0);
     }
+    m_regions.front()->calculateExtremalSizes();
   }
 
   // Finally, apply Region geometries found


### PR DESCRIPTION
This fixes the issue where some resize handles weren't showing on hover.  This affected panels that could be fixed width.