### PR TITLE
Segment Eraser for Smart Raster Levels

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -76,7 +76,7 @@ DVAPI void inkFill(const TRasterCM32P &r, const TPoint &p, int ink,
 
 bool DVAPI inkSegment(const TRasterCM32P &r, const TPoint &p, int ink,
                       float growFactor, bool isSelective,
-                      TTileSaverCM32 *saver = 0);
+                      TTileSaverCM32 *saver = 0, bool clearInk = false);
 
 void DVAPI rectFillInk(const TRasterCM32P &ras, const TRect &r, int color);
 


### PR DESCRIPTION
This adds a segment eraser mode for smart raster levels.

This is pretty accurate, but not as accurate as the segment eraser for vectors.

Since it is dealing with pixels, there is some guess work around where the segments are.  It uses the same code as the segment fill.